### PR TITLE
Add WC3 ownership verification

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,18 @@
+# MongoDB
+MONGO_USERNAME=w3champions
+MONGO_PASSWORD=your-mongo-password-here
+
+# Battle.net API
+BNET_API_CLIENT_ID=your-bnet-client-id
+BNET_API_SECRET=your-bnet-secret
+
+# Twitch API
+TWITCH_API_SECRET=your-twitch-api-secret
+
+# JWT Keys
+JWT_PRIVATE_KEY=-----BEGIN RSA PRIVATE KEY-----\nYOUR_PRIVATE_KEY_HERE\n-----END RSA PRIVATE KEY-----
+JWT_PUBLIC_KEY=-----BEGIN PUBLIC KEY-----\nYOUR_PUBLIC_KEY_HERE\n-----END PUBLIC KEY-----
+
+# Azure AD
+AAD_APP_CLIENT_ID=your-aad-client-id
+AAD_APP_CLIENT_SECRET=your-aad-client-secret

--- a/.gitignore
+++ b/.gitignore
@@ -334,3 +334,5 @@ ASALocalRun/
 
 # VSCode
 .vscode
+
+.env

--- a/W3ChampionsIdentificationService/Blizzard/BlizzardApiError.cs
+++ b/W3ChampionsIdentificationService/Blizzard/BlizzardApiError.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace W3ChampionsIdentificationService.Blizzard;
+
+public class BlizzardApiError
+{
+    public class ErrorCode(string code, string description, bool isRetryable)
+    {
+        public string Code { get; } = code;
+        public string Description { get; } = description;
+        public bool IsRetryable { get; } = isRetryable;
+
+        public static ErrorCode GeneralError = new("BLZBTNSHR10010101", "General error or the client has been throttled due to high traffic. Check the current error message.", true);
+        public static ErrorCode InputParameterMissing = new("BLZBTNSHR10010102", "An input parameter was either missing or malformed. See the 'error' response for details.", false);
+        public static ErrorCode NoBattleNetAccountFound = new("BLZBTNSPS10000001", "No BattleNet Account can be found.", false);
+
+        private static readonly Dictionary<string, ErrorCode> _errorCodes = new()
+        {
+            { GeneralError.Code, GeneralError },
+            { InputParameterMissing.Code, InputParameterMissing },
+            { NoBattleNetAccountFound.Code, NoBattleNetAccountFound },
+        };
+
+        public static ErrorCode FromCode(string code) => _errorCodes.TryGetValue(code, out var errorCode) ? errorCode : new ErrorCode(code, $"Unknown error: {code}", false);
+    }
+
+    [JsonConverter(typeof(ErrorCodeJsonConverter))]
+    public ErrorCode code { get; }
+    public string message { get; }
+    public string supplementalInfo { get; }
+    public string errorHierarchy { get; }
+    public string category { get; }
+}
+
+public class ErrorCodeJsonConverter : JsonConverter<BlizzardApiError.ErrorCode>
+{
+    public override BlizzardApiError.ErrorCode Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+
+        if (reader.TokenType == JsonTokenType.String)
+        {
+            var errorCodeString = reader.GetString();
+            return BlizzardApiError.ErrorCode.FromCode(errorCodeString);
+        }
+
+        if (reader.TokenType == JsonTokenType.Null)
+        {
+            return null;
+        }
+
+        throw new JsonException($"Unexpected token type: {reader.TokenType}");
+    }
+
+    public override void Write(Utf8JsonWriter writer, BlizzardApiError.ErrorCode value, JsonSerializerOptions options)
+    {
+        if (value == null)
+        {
+            writer.WriteNullValue();
+        }
+        else
+        {
+            writer.WriteStringValue(value.Code);
+        }
+    }
+}

--- a/W3ChampionsIdentificationService/Blizzard/BlizzardAuthenticationService.cs
+++ b/W3ChampionsIdentificationService/Blizzard/BlizzardAuthenticationService.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text.Json;
@@ -12,35 +13,75 @@ public class BlizzardAuthenticationService : IBlizzardAuthenticationService
     private readonly string _bnetClientId = Environment.GetEnvironmentVariable("BNET_API_CLIENT_ID");
     private readonly string _bnetApiSecret = Environment.GetEnvironmentVariable("BNET_API_SECRET");
 
+    private const string StreamingProviderEndpoint = "/StreamingProviderService/v1/GetPlayableTitles";
+    private const string UserInfoEndpoint = "/oauth/userinfo";
+    private const string TokenEndpoint = "/oauth/token";
+
     public async Task<BlizzardUserInfo> GetUser(string bearer, BnetRegion region)
     {
-        var httpClient = new HttpClient();
-        httpClient.BaseAddress = new Uri($"{GetAuthenticationUri(region)}/oauth/userinfo");
+        using var httpClient = new HttpClient();
+        httpClient.BaseAddress = new Uri($"{GetAuthenticationUri(region)}{UserInfoEndpoint}");
         httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", bearer);
 
         var res = await httpClient.GetAsync("");
         if (!res.IsSuccessStatusCode)
         {
-            Log.Error("Failed to get user info from Blizzard: {StatusCode}", res.StatusCode);
+            var errorContent = await res.Content.ReadAsStringAsync();
+            Log.Error("Failed to get user info from Blizzard: [{ErrorCode}] {response}", res.StatusCode, errorContent);
             return null;
         }
 
-        var readAsStringAsync = await res.Content.ReadAsStringAsync();
-        return JsonSerializer.Deserialize<BlizzardUserInfo>(readAsStringAsync);
+        var content = await res.Content.ReadAsStringAsync();
+        return JsonSerializer.Deserialize<BlizzardUserInfo>(content);
     }
 
     public async Task<OAuthToken> GetToken(string code, string redirectUri, BnetRegion region)
     {
-        var httpClient = new HttpClient();
-        httpClient.BaseAddress = new Uri($"{GetAuthenticationUri(region)}/oauth/token");
+        using var httpClient = new HttpClient();
+        httpClient.BaseAddress = new Uri($"{GetAuthenticationUri(region)}{TokenEndpoint}");
         var res = await httpClient.PostAsync($"?code={code}&grant_type=authorization_code&redirect_uri={redirectUri}&client_id={_bnetClientId}&client_secret={_bnetApiSecret}", null);
         if (!res.IsSuccessStatusCode)
         {
+            var errorContent = await res.Content.ReadAsStringAsync();
+            Log.Error("Failed to get token from Blizzard: [{ErrorCode}] {response}", res.StatusCode, errorContent);
             return null;
         }
 
-        var readAsStringAsync = await res.Content.ReadAsStringAsync();
-        return JsonSerializer.Deserialize<OAuthToken>(readAsStringAsync);
+        var content = await res.Content.ReadAsStringAsync();
+        return JsonSerializer.Deserialize<OAuthToken>(content);
+    }
+
+    public async Task<List<BlizzardPlayableTitle>> GetPlayableTitles(string bearer, BnetRegion region)
+    {
+        using var httpClient = new HttpClient();
+        httpClient.BaseAddress = new Uri($"{GetPartnerUri(region)}{StreamingProviderEndpoint}");
+        httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", bearer);
+        httpClient.DefaultRequestHeaders.Add("Accept", "application/json");
+
+        var requestContent = new StringContent("{}", System.Text.Encoding.UTF8, "application/json");
+        var res = await httpClient.PostAsync("", requestContent);
+        if (!res.IsSuccessStatusCode)
+        {
+            var errorContent = await res.Content.ReadAsStringAsync();
+            Log.Error("Failed to get playable titles from Blizzard: [{ErrorCode}] {response}", res.StatusCode, errorContent);
+            return null;
+        }
+
+        var content = await res.Content.ReadAsStringAsync();
+        var apiResponse = JsonSerializer.Deserialize<GetPlayableTitlesResponse>(content);
+
+        if (apiResponse?.error != null)
+        {
+            Log.Error("Failed to get playable titles from Blizzard: [{ErrorCode}] {ErrorDescription}", apiResponse.error.code?.Code, apiResponse.error.code?.Description);
+            return null;
+        }
+
+        if (apiResponse?.titleCodes == null || apiResponse.titleCodes.Length == 0)
+        {
+            return new List<BlizzardPlayableTitle>();
+        }
+
+        return BlizzardPlayableTitleExtensions.FromTitleCodes(apiResponse.titleCodes);
     }
 
     private static string GetAuthenticationUri(BnetRegion bnetRegion)
@@ -48,11 +89,25 @@ public class BlizzardAuthenticationService : IBlizzardAuthenticationService
         switch (bnetRegion)
         {
             case BnetRegion.eu:
-                return "https://eu.battle.net";
+                return "https://oauth.battle.net";
             case BnetRegion.cn:
-                return "https://www.battlenet.com.cn";
+                return "https://oauth.battlenet.com.cn";
             default:
-                return "https://eu.battle.net";
+                return "https://oauth.battle.net";
+        }
+    }
+
+    private static string GetPartnerUri(BnetRegion bnetRegion)
+    {
+        // The US endpoint is the only endpoint for the entire global world.
+        switch (bnetRegion)
+        {
+            case BnetRegion.eu:
+                return "https://partner-us.api.blizzard.com";
+            case BnetRegion.cn:
+                return "https://partner-us.api.blizzard.com"; // TODO: Get china endpoint
+            default:
+                return "https://partner-us.api.blizzard.com";
         }
     }
 }

--- a/W3ChampionsIdentificationService/Blizzard/BlizzardPlayableTitle.cs
+++ b/W3ChampionsIdentificationService/Blizzard/BlizzardPlayableTitle.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace W3ChampionsIdentificationService.Blizzard;
+
+public enum BlizzardPlayableTitle
+{
+    BlizzardArcadeCollection = 1381257807,
+    CallOfDutyHQ = 1096108883,
+    CallOfDutyBlackOps4 = 1447645266,
+    CallOfDutyBlackOps4BlackOpsPass = 1112486992,
+    CallOfDutyBlackOps4ClassifiedZombiesExperience = 1112487002,
+    CallOfDutyBlackOpsColdWar = 1514493267,
+    CallOfDutyModernWarfare = 1329875278,
+    CallOfDutyModernWarfareII = 1297566025,
+    CallOfDutyModernWarfareIII = 5068595,
+    CallOfDutyMW2Remastered = 1279351378,
+    CallOfDutyVanguard = 1179603525,
+    CrashBandicoot4 = 1464615513,
+    Diablo = 1146246220,
+    Diablo2Resurrected = 5198665,
+    DiabloImmortal = 1095647827,
+    DiabloIV = 4613486,
+    Diablo2 = 1144144982,
+    Diablo2Expansion = 1144150096,
+    Diablo3 = 17459,
+    Diablo3ReaperOfSouls = 1144215632,
+    Hearthstone = 1465140039,
+    HeroesOfTheStorm = 1214607983,
+    Overwatch2 = 5272175,
+    StarCraft = 1398030674,
+    StarCraftRemastered = 21297,
+    StarCraft2 = 21298,
+    StarCraft2WingsOfLiberty = 1395804243,
+    StarCraft2HeartOfTheSwarm = 1395805270,
+    StarCraft2LegacyOfTheVoid = 1395808076,
+    WarcraftOrcsAndHumans = 1463898673,
+    Warcraft2 = 1462911566,
+    Warcraft3ReignOfChaos = 1463898675,
+    Warcraft3FrozenThrone = 1462982736,
+    Warcraft3Reforged = 22323,
+    WarcraftRumble = 4674137,
+    WorldOfWarcraft = 5730135,
+    WorldOfWarcraftDragonflight = 1464817475,
+    WorldOfWarcraftClassicAndExpansions = 1465397552,
+}
+
+public static class BlizzardPlayableTitleExtensions
+{
+    public static List<BlizzardPlayableTitle> FromTitleCodes(string[] titleCodes)
+    {
+        return (titleCodes ?? Array.Empty<string>())
+            .Where(titleCode => int.TryParse(titleCode, out var titleId) &&
+                               Enum.IsDefined(typeof(BlizzardPlayableTitle), titleId))
+            .Select(titleCode => (BlizzardPlayableTitle)int.Parse(titleCode))
+            .ToList();
+    }
+}

--- a/W3ChampionsIdentificationService/Blizzard/GetPlayableTitlesResponse.cs
+++ b/W3ChampionsIdentificationService/Blizzard/GetPlayableTitlesResponse.cs
@@ -1,0 +1,8 @@
+namespace W3ChampionsIdentificationService.Blizzard;
+
+public class GetPlayableTitlesResponse : IBlizzardApiResponse
+{
+    public BlizzardApiError error { get; set; }
+    public string accountId { get; set; }
+    public string[] titleCodes { get; set; }
+}

--- a/W3ChampionsIdentificationService/Blizzard/IBlizzardApiResponse.cs
+++ b/W3ChampionsIdentificationService/Blizzard/IBlizzardApiResponse.cs
@@ -1,0 +1,8 @@
+namespace W3ChampionsIdentificationService.Blizzard;
+
+public interface IBlizzardApiResponse
+{
+    public BlizzardApiError error { get; set; }
+    public string accountId { get; set; }
+    public bool IsError => error != null;
+}

--- a/W3ChampionsIdentificationService/Blizzard/IBlizzardAuthenticationService.cs
+++ b/W3ChampionsIdentificationService/Blizzard/IBlizzardAuthenticationService.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace W3ChampionsIdentificationService.Blizzard;
 
@@ -6,4 +7,6 @@ public interface IBlizzardAuthenticationService
 {
     Task<BlizzardUserInfo> GetUser(string bearer, BnetRegion region);
     Task<OAuthToken> GetToken(string code, string redirectUri, BnetRegion region);
+
+    Task<List<BlizzardPlayableTitle>> GetPlayableTitles(string bearer, BnetRegion region);
 }

--- a/W3ChampionsIdentificationService/Blizzard/PlayableTitleError.cs
+++ b/W3ChampionsIdentificationService/Blizzard/PlayableTitleError.cs
@@ -1,0 +1,30 @@
+using System.Text.Json.Serialization;
+
+namespace W3ChampionsIdentificationService.Blizzard;
+
+public class PlayableTitleError
+{
+    [JsonPropertyName("errorCode")]
+    public string ErrorCode { get; set; }
+
+    [JsonPropertyName("message")]
+    public string Message { get; set; }
+
+    public static PlayableTitleError ApiCallFailed()
+    {
+        return new PlayableTitleError
+        {
+            ErrorCode = "PLAYABLE_TITLES_API_FAILED",
+            Message = "Unable to get playable titles"
+        };
+    }
+
+    public static PlayableTitleError MissingWarcraft3()
+    {
+        return new PlayableTitleError
+        {
+            ErrorCode = "MISSING_WARCRAFT_3",
+            Message = "You need to have Warcraft 3 purchased."
+        };
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,37 @@
+name: w3champions-identification-service-local
+services:
+  w3champions-identification-service:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: identification-service-local
+    restart: unless-stopped
+    ports:
+      - "5050:80"
+    environment:
+      - MONGO_CONNECTION_STRING=mongodb://${MONGO_USERNAME}:${MONGO_PASSWORD}@mongo-db:27017
+      - BNET_API_CLIENT_ID=${BNET_API_CLIENT_ID}
+      - BNET_API_SECRET=${BNET_API_SECRET}
+      - TWITCH_API_SECRET=${TWITCH_API_SECRET}
+      - JWT_PRIVATE_KEY=${JWT_PRIVATE_KEY}
+      - JWT_PUBLIC_KEY=${JWT_PUBLIC_KEY}
+      - AAD_APP_CLIENT_ID=${AAD_APP_CLIENT_ID}
+      - AAD_APP_CLIENT_SECRET=${AAD_APP_CLIENT_SECRET}
+    depends_on:
+      - mongo-db
+
+  mongo-db:
+    image: mongo:7.0.19
+    container_name: db-identification-service-local
+    restart: unless-stopped
+    ports:
+      - "27077:27017"
+    command: --wiredTigerCacheSizeGB=0.25
+    environment:
+      - MONGO_INITDB_ROOT_USERNAME=${MONGO_USERNAME}
+      - MONGO_INITDB_ROOT_PASSWORD=${MONGO_PASSWORD}
+    volumes:
+      - mongo-db-w3champions-identification-local:/data/db
+
+volumes:
+  mongo-db-w3champions-identification-local:


### PR DESCRIPTION
This PR adds WC3 ownership verification so that we're no longer reliant on reading the game client.