### PR TITLE
feat: surface canonical BattleTag from /api/users/exists + indexed lookup

### DIFF
--- a/W3ChampionsIdentificationService.Tests/IntegrationTests/RolesAndPermissions/Repositories/UsersRepoTests.cs
+++ b/W3ChampionsIdentificationService.Tests/IntegrationTests/RolesAndPermissions/Repositories/UsersRepoTests.cs
@@ -1,4 +1,5 @@
 ﻿using AutoFixture;
+using MongoDB.Bson;
 using MongoDB.Driver;
 using NUnit.Framework;
 using System.Collections.Generic;
@@ -200,17 +201,100 @@ public class UsersRepoTests : IntegrationTestBase
     [Test]
     public async Task MigrateIdNormalized_Idempotent_RunningTwiceMatchesNoDocs()
     {
-        var rawColl = CreateClient().GetCollection<MongoDB.Bson.BsonDocument>("User");
-        await rawColl.InsertOneAsync(new MongoDB.Bson.BsonDocument
+        var rawColl = CreateClient().GetCollection<BsonDocument>("User");
+        await rawColl.InsertOneAsync(new BsonDocument
         {
-            { "_id", "Once#1" }, { "BnetId", "1" }, { "Roles", new MongoDB.Bson.BsonArray() }
+            { "_id", "Once#1" }, { "BnetId", "1" }, { "Roles", new BsonArray() }
         });
 
         var userRepo = new UsersRepository(_mongoClient, _appConfig);
         await userRepo.MigrateIdNormalized();
-        Assert.DoesNotThrowAsync(async () => await userRepo.MigrateIdNormalized());
 
-        var doc = await rawColl.Find(MongoDB.Driver.Builders<MongoDB.Bson.BsonDocument>.Filter.Eq("_id", "Once#1")).FirstOrDefaultAsync();
+        // Verify first run populated IdNormalized
+        var doc = await rawColl.Find(Builders<BsonDocument>.Filter.Eq("_id", "Once#1")).FirstOrDefaultAsync();
         Assert.AreEqual("once#1", doc["IdNormalized"].AsString);
+
+        // After the second run, no docs without IdNormalized should remain
+        await userRepo.MigrateIdNormalized();
+        var remainingCount = await rawColl
+            .Find(Builders<BsonDocument>.Filter.Exists("IdNormalized", false))
+            .CountDocumentsAsync();
+        Assert.AreEqual(0, remainingCount, "Second run must leave no docs without IdNormalized.");
+    }
+
+    // Fix 2: Actual duplicate-insert test for unique index
+    [Test]
+    public async Task CreateIndex_UniqueConstraint_RejectsDuplicateLowercasedId()
+    {
+        // Arrange
+        var userRepo = new UsersRepository(_mongoClient, _appConfig);
+        await userRepo.CreateIndex();
+
+        var user1 = new User { Id = "Foo#1", BnetId = "100", Roles = new List<string>() };
+        await userRepo.CreateUser(user1);
+
+        // Act & Assert — inserting a user whose IdNormalized collides with the first
+        var user2 = new User { Id = "FOO#1", BnetId = "101", Roles = new List<string>() };
+        var ex = Assert.ThrowsAsync<MongoWriteException>(
+            async () => await userRepo.CreateUser(user2));
+
+        Assert.IsNotNull(ex, "Expected MongoWriteException for duplicate-key violation.");
+        Assert.IsTrue(
+            ex.WriteError.Category == ServerErrorCategory.DuplicateKey,
+            $"Expected DuplicateKey error category, got: {ex.WriteError.Category}");
+    }
+
+    // Fix 4: Migration test for legacy _id shapes
+    [Test]
+    public async Task MigrateIdNormalized_NonStringId_IsLeftUntouched()
+    {
+        // Insert a doc with a non-string ObjectId as _id (legacy shape)
+        var rawColl = CreateClient().GetCollection<BsonDocument>("User");
+        var objectId = ObjectId.GenerateNewId();
+        await rawColl.InsertOneAsync(new BsonDocument
+        {
+            { "_id", objectId },
+            { "BnetId", "42" },
+            { "Roles", new BsonArray() }
+            // No IdNormalized
+        });
+
+        var userRepo = new UsersRepository(_mongoClient, _appConfig);
+        await userRepo.MigrateIdNormalized();
+
+        var doc = await rawColl
+            .Find(Builders<BsonDocument>.Filter.Eq("_id", objectId))
+            .FirstOrDefaultAsync();
+
+        Assert.IsNotNull(doc);
+        Assert.IsFalse(doc.Contains("IdNormalized"),
+            "Migration must NOT add IdNormalized to docs with non-string _id.");
+    }
+
+    [Test]
+    public async Task MigrateIdNormalized_EmptyStringId_SetsIdNormalizedToEmptyString()
+    {
+        // Insert a doc with empty-string _id (edge case)
+        var rawColl = CreateClient().GetCollection<BsonDocument>("User");
+        await rawColl.InsertOneAsync(new BsonDocument
+        {
+            { "_id", "" },
+            { "BnetId", "0" },
+            { "Roles", new BsonArray() }
+            // No IdNormalized
+        });
+
+        var userRepo = new UsersRepository(_mongoClient, _appConfig);
+        await userRepo.MigrateIdNormalized();
+
+        var doc = await rawColl
+            .Find(Builders<BsonDocument>.Filter.Eq("_id", ""))
+            .FirstOrDefaultAsync();
+
+        Assert.IsNotNull(doc);
+        Assert.IsTrue(doc.Contains("IdNormalized"),
+            "Migration must add IdNormalized even when _id is empty string.");
+        Assert.AreEqual("", doc["IdNormalized"].AsString,
+            "IdNormalized must be empty string when _id is empty string.");
     }
 }

--- a/W3ChampionsIdentificationService.Tests/IntegrationTests/RolesAndPermissions/Repositories/UsersRepoTests.cs
+++ b/W3ChampionsIdentificationService.Tests/IntegrationTests/RolesAndPermissions/Repositories/UsersRepoTests.cs
@@ -2,6 +2,7 @@
 using MongoDB.Driver;
 using NUnit.Framework;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using W3ChampionsIdentificationService.RolesAndPermissions;
 using W3ChampionsIdentificationService.RolesAndPermissions.Repositories;
@@ -125,5 +126,36 @@ public class UsersRepoTests : IntegrationTestBase
         // assert
         Assert.IsNotNull(persisted);
         Assert.AreEqual("mixedcase#0001", persisted.IdNormalized);
+    }
+
+    [Test]
+    public async Task CreateIndex_CreatesUniqueIndexOnIdNormalized()
+    {
+        // arrange
+        var userRepo = new UsersRepository(_mongoClient, _appConfig);
+
+        // act
+        await userRepo.CreateIndex();
+
+        // assert
+        var coll = CreateCollection<User>();
+        var indexes = await (await coll.Indexes.ListAsync()).ToListAsync();
+        var idNormalizedIndex = indexes.FirstOrDefault(i => i["name"] == "IdNormalized_unique");
+
+        Assert.IsNotNull(idNormalizedIndex,
+            $"Expected an index named 'IdNormalized_unique' but found: {string.Join(",", indexes.Select(i => i["name"].AsString))}");
+        Assert.IsTrue(idNormalizedIndex["unique"].AsBoolean,
+            "Index must be unique to prevent future casing-duplicate inserts.");
+    }
+
+    [Test]
+    public async Task CreateIndex_Idempotent_RunningTwiceDoesNotThrow()
+    {
+        // arrange
+        var userRepo = new UsersRepository(_mongoClient, _appConfig);
+
+        // act & assert
+        await userRepo.CreateIndex();
+        Assert.DoesNotThrowAsync(async () => await userRepo.CreateIndex());
     }
 }

--- a/W3ChampionsIdentificationService.Tests/IntegrationTests/RolesAndPermissions/Repositories/UsersRepoTests.cs
+++ b/W3ChampionsIdentificationService.Tests/IntegrationTests/RolesAndPermissions/Repositories/UsersRepoTests.cs
@@ -158,4 +158,59 @@ public class UsersRepoTests : IntegrationTestBase
         await userRepo.CreateIndex();
         Assert.DoesNotThrowAsync(async () => await userRepo.CreateIndex());
     }
+
+    [Test]
+    public async Task MigrateIdNormalized_BackfillsMissingField()
+    {
+        // Insert a doc directly with IdNormalized field absent (raw BSON)
+        var rawColl = CreateClient().GetCollection<MongoDB.Bson.BsonDocument>("User");
+        await rawColl.InsertOneAsync(new MongoDB.Bson.BsonDocument
+        {
+            { "_id", "PreMigration#9999" },
+            { "BnetId", "999" },
+            { "Roles", new MongoDB.Bson.BsonArray() },
+            // No IdNormalized
+        });
+
+        var userRepo = new UsersRepository(_mongoClient, _appConfig);
+        await userRepo.MigrateIdNormalized();
+
+        var migrated = await rawColl.Find(MongoDB.Driver.Builders<MongoDB.Bson.BsonDocument>.Filter.Eq("_id", "PreMigration#9999")).FirstOrDefaultAsync();
+        Assert.IsNotNull(migrated);
+        Assert.IsTrue(migrated.Contains("IdNormalized"), "Migration must add IdNormalized field.");
+        Assert.AreEqual("premigration#9999", migrated["IdNormalized"].AsString);
+    }
+
+    [Test]
+    public async Task MigrateIdNormalized_DoesNotOverwriteExistingField()
+    {
+        var userRepo = new UsersRepository(_mongoClient, _appConfig);
+        var canonical = new User { Id = "Existing#1234", BnetId = "x", Roles = new System.Collections.Generic.List<string>() };
+        await userRepo.CreateUser(canonical);
+        // Setter populated IdNormalized to "existing#1234"
+
+        await userRepo.MigrateIdNormalized();
+
+        var rawColl = CreateClient().GetCollection<MongoDB.Bson.BsonDocument>("User");
+        var doc = await rawColl.Find(MongoDB.Driver.Builders<MongoDB.Bson.BsonDocument>.Filter.Eq("_id", "Existing#1234")).FirstOrDefaultAsync();
+        Assert.AreEqual("existing#1234", doc["IdNormalized"].AsString,
+            "Migration should not modify already-populated IdNormalized values.");
+    }
+
+    [Test]
+    public async Task MigrateIdNormalized_Idempotent_RunningTwiceMatchesNoDocs()
+    {
+        var rawColl = CreateClient().GetCollection<MongoDB.Bson.BsonDocument>("User");
+        await rawColl.InsertOneAsync(new MongoDB.Bson.BsonDocument
+        {
+            { "_id", "Once#1" }, { "BnetId", "1" }, { "Roles", new MongoDB.Bson.BsonArray() }
+        });
+
+        var userRepo = new UsersRepository(_mongoClient, _appConfig);
+        await userRepo.MigrateIdNormalized();
+        Assert.DoesNotThrowAsync(async () => await userRepo.MigrateIdNormalized());
+
+        var doc = await rawColl.Find(MongoDB.Driver.Builders<MongoDB.Bson.BsonDocument>.Filter.Eq("_id", "Once#1")).FirstOrDefaultAsync();
+        Assert.AreEqual("once#1", doc["IdNormalized"].AsString);
+    }
 }

--- a/W3ChampionsIdentificationService.Tests/IntegrationTests/RolesAndPermissions/Repositories/UsersRepoTests.cs
+++ b/W3ChampionsIdentificationService.Tests/IntegrationTests/RolesAndPermissions/Repositories/UsersRepoTests.cs
@@ -1,4 +1,5 @@
 ﻿using AutoFixture;
+using MongoDB.Driver;
 using NUnit.Framework;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -70,5 +71,59 @@ public class UsersRepoTests : IntegrationTestBase
         Assert.AreEqual(listOfUsers[6].Id, users[2].Id, "Third user is not correct");
         Assert.AreEqual(listOfUsers[7].Id, users[3].Id, "Fourth user is not correct");
         Assert.AreEqual(10, allUsers.Count, "Incorrect number of users returned by GetAllUsers()");
+    }
+
+    [Test]
+    public async Task GetUser_CaseInsensitiveMatch_ReturnsCanonicalUser()
+    {
+        // arrange
+        var userRepo = new UsersRepository(_mongoClient, _appConfig);
+        var canonical = new User { Id = "TORREN#11438", BnetId = "811045114", Roles = new List<string>() };
+        await userRepo.CreateUser(canonical);
+
+        // act
+        var foundLower = await userRepo.GetUser("torren#11438");
+        var foundMixed = await userRepo.GetUser("Torren#11438");
+        var foundExact = await userRepo.GetUser("TORREN#11438");
+
+        // assert
+        Assert.IsNotNull(foundLower);
+        Assert.AreEqual("TORREN#11438", foundLower.Id, "Lowercase query must return the canonical-cased user.");
+        Assert.IsNotNull(foundMixed);
+        Assert.AreEqual("TORREN#11438", foundMixed.Id);
+        Assert.IsNotNull(foundExact);
+        Assert.AreEqual("TORREN#11438", foundExact.Id);
+    }
+
+    [Test]
+    public async Task GetUser_NoMatch_ReturnsNull()
+    {
+        // arrange
+        var userRepo = new UsersRepository(_mongoClient, _appConfig);
+        var canonical = new User { Id = "Existing#1111", BnetId = "1", Roles = new List<string>() };
+        await userRepo.CreateUser(canonical);
+
+        // act
+        var result = await userRepo.GetUser("nonexistent#9999");
+
+        // assert
+        Assert.IsNull(result);
+    }
+
+    [Test]
+    public async Task CreateUser_PopulatesIdNormalizedInPersistedDocument()
+    {
+        // arrange
+        var userRepo = new UsersRepository(_mongoClient, _appConfig);
+        var user = new User { Id = "MixedCase#0001", BnetId = "x", Roles = new List<string>() };
+        await userRepo.CreateUser(user);
+
+        // act
+        var coll = CreateCollection<User>();
+        var persisted = await coll.Find(x => x.Id == "MixedCase#0001").FirstOrDefaultAsync();
+
+        // assert
+        Assert.IsNotNull(persisted);
+        Assert.AreEqual("mixedcase#0001", persisted.IdNormalized);
     }
 }

--- a/W3ChampionsIdentificationService.Tests/UnitTests/RolesAndPermissions/Controllers/UsersControllerTests.cs
+++ b/W3ChampionsIdentificationService.Tests/UnitTests/RolesAndPermissions/Controllers/UsersControllerTests.cs
@@ -1,0 +1,86 @@
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using NUnit.Framework;
+using W3ChampionsIdentificationService.RolesAndPermissions;
+using W3ChampionsIdentificationService.RolesAndPermissions.Contracts;
+using W3ChampionsIdentificationService.RolesAndPermissions.Controllers;
+
+namespace W3ChampionsIdentificationService.Tests.UnitTests.RolesAndPermissions.Controllers;
+
+[TestFixture]
+public class UsersControllerTests
+{
+    private Mock<IUsersRepository> _usersRepositoryMock;
+    private Mock<IUsersCommandHandler> _usersCommandHandlerMock;
+    private UsersController _controller;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _usersRepositoryMock = new Mock<IUsersRepository>();
+        _usersCommandHandlerMock = new Mock<IUsersCommandHandler>();
+        _controller = new UsersController(_usersRepositoryMock.Object, _usersCommandHandlerMock.Object);
+    }
+
+    [Test]
+    public async Task Exists_UserFound_ReturnsOkWithCanonicalId()
+    {
+        const string canonicalBattleTag = "TORREN#11438";
+        const string queryWithDifferentCasing = "torren#11438";
+
+        _usersRepositoryMock
+            .Setup(r => r.GetUser(queryWithDifferentCasing))
+            .ReturnsAsync(new User { Id = canonicalBattleTag, BnetId = "811045114" });
+
+        var result = await _controller.Exists(queryWithDifferentCasing);
+
+        var okResult = result as OkObjectResult;
+        Assert.IsNotNull(okResult, "Expected 200 OK with body, got {0}", result?.GetType().Name);
+        Assert.AreEqual(200, okResult.StatusCode);
+
+        var body = okResult.Value as UserExistsResponse;
+        Assert.IsNotNull(body, "Response body should be a UserExistsResponse");
+        Assert.AreEqual(canonicalBattleTag, body.Id,
+            "Body must contain the canonical Id from the matched user, not the request casing.");
+    }
+
+    [Test]
+    public async Task Exists_UserFoundWithExactCasing_ReturnsOkWithSameCanonicalId()
+    {
+        const string canonicalBattleTag = "Faro#2494";
+
+        _usersRepositoryMock
+            .Setup(r => r.GetUser(canonicalBattleTag))
+            .ReturnsAsync(new User { Id = canonicalBattleTag });
+
+        var result = await _controller.Exists(canonicalBattleTag);
+
+        var okResult = result as OkObjectResult;
+        Assert.IsNotNull(okResult);
+        var body = okResult.Value as UserExistsResponse;
+        Assert.IsNotNull(body);
+        Assert.AreEqual(canonicalBattleTag, body.Id);
+    }
+
+    [Test]
+    public async Task Exists_UserNotFound_ReturnsNotFound()
+    {
+        _usersRepositoryMock
+            .Setup(r => r.GetUser(It.IsAny<string>()))
+            .ReturnsAsync((User)null);
+
+        var result = await _controller.Exists("nonexistent#9999");
+
+        Assert.IsInstanceOf<NotFoundObjectResult>(result);
+    }
+
+    [Test]
+    public async Task Exists_NullId_ReturnsBadRequest()
+    {
+        var result = await _controller.Exists(null);
+
+        Assert.IsInstanceOf<BadRequestObjectResult>(result);
+        _usersRepositoryMock.Verify(r => r.GetUser(It.IsAny<string>()), Times.Never);
+    }
+}

--- a/W3ChampionsIdentificationService.Tests/UnitTests/RolesAndPermissions/UserTests.cs
+++ b/W3ChampionsIdentificationService.Tests/UnitTests/RolesAndPermissions/UserTests.cs
@@ -1,0 +1,39 @@
+using NUnit.Framework;
+using W3ChampionsIdentificationService.RolesAndPermissions;
+
+namespace W3ChampionsIdentificationService.Tests.UnitTests.RolesAndPermissions;
+
+[TestFixture]
+public class UserTests
+{
+    [Test]
+    public void SetId_PopulatesIdNormalized()
+    {
+        var user = new User { Id = "TORREN#11438" };
+
+        Assert.AreEqual("TORREN#11438", user.Id);
+        Assert.AreEqual("torren#11438", user.IdNormalized,
+            "Setting Id must auto-populate IdNormalized to the lowercased form.");
+    }
+
+    [Test]
+    public void SetIdToNull_IdNormalizedIsNull()
+    {
+        var user = new User { Id = "Foo#1234" };
+        Assert.AreEqual("foo#1234", user.IdNormalized);
+
+        user.Id = null;
+
+        Assert.IsNull(user.Id);
+        Assert.IsNull(user.IdNormalized);
+    }
+
+    [Test]
+    public void SetId_AlreadyLowercase_IdNormalizedMatchesId()
+    {
+        var user = new User { Id = "lowtag#0001" };
+
+        Assert.AreEqual("lowtag#0001", user.Id);
+        Assert.AreEqual("lowtag#0001", user.IdNormalized);
+    }
+}

--- a/W3ChampionsIdentificationService.Tests/UnitTests/RolesAndPermissions/UserTests.cs
+++ b/W3ChampionsIdentificationService.Tests/UnitTests/RolesAndPermissions/UserTests.cs
@@ -36,4 +36,12 @@ public class UserTests
         Assert.AreEqual("lowtag#0001", user.Id);
         Assert.AreEqual("lowtag#0001", user.IdNormalized);
     }
+
+    [Test]
+    public void SetIdToEmptyString_IdNormalizedIsEmptyString()
+    {
+        var user = new User { Id = "" };
+        Assert.AreEqual("", user.Id);
+        Assert.AreEqual("", user.IdNormalized);
+    }
 }

--- a/W3ChampionsIdentificationService/MigratorHostedService.cs
+++ b/W3ChampionsIdentificationService/MigratorHostedService.cs
@@ -4,6 +4,7 @@ using System;
 using System.Threading.Tasks;
 using System.Threading;
 using W3ChampionsIdentificationService.Identity.Contracts;
+using W3ChampionsIdentificationService.RolesAndPermissions.Contracts;
 
 namespace W3ChampionsIdentificationService;
 
@@ -14,6 +15,10 @@ public class MigratorHostedService(IServiceProvider serviceProvider) : IHostedSe
     public async Task StartAsync(CancellationToken cancellationToken)
     {
         await _serviceProvider.GetService<IMicrosoftIdentityRepository>().CreateIndex();
+
+        var usersRepo = _serviceProvider.GetService<IUsersRepository>();
+        await usersRepo.MigrateIdNormalized();
+        await usersRepo.CreateIndex();
     }
 
     // noop

--- a/W3ChampionsIdentificationService/RolesAndPermissions/Contracts/IUsersRepository.cs
+++ b/W3ChampionsIdentificationService/RolesAndPermissions/Contracts/IUsersRepository.cs
@@ -11,4 +11,5 @@ public interface IUsersRepository
     public Task UpdateUser(User user);
     public Task DeleteUser(string id);
     public Task CreateIndex();
+    public Task MigrateIdNormalized();
 }

--- a/W3ChampionsIdentificationService/RolesAndPermissions/Contracts/IUsersRepository.cs
+++ b/W3ChampionsIdentificationService/RolesAndPermissions/Contracts/IUsersRepository.cs
@@ -10,4 +10,5 @@ public interface IUsersRepository
     public Task CreateUser(User user);
     public Task UpdateUser(User user);
     public Task DeleteUser(string id);
+    public Task CreateIndex();
 }

--- a/W3ChampionsIdentificationService/RolesAndPermissions/Controllers/UsersController.cs
+++ b/W3ChampionsIdentificationService/RolesAndPermissions/Controllers/UsersController.cs
@@ -54,6 +54,10 @@ public class UsersController(
         return Ok();
     }
 
+    // Returns the canonical-cased Id of the matched user when found.
+    // Lookup is case-insensitive (see UsersRepository.GetUser); the response body lets
+    // callers reconcile arbitrary-cased input back to the canonical Battle.net casing
+    // stored at first OAuth.
     [HttpGet("exists")]
     public async Task<IActionResult> Exists([FromQuery] string id)
     {
@@ -62,6 +66,8 @@ public class UsersController(
             return BadRequest("No user id supplied.");
         }
         User user = await _usersRepository.GetUser(id);
-        return user == null ? NotFound($"User {id} not found.") : Ok();
+        return user == null
+            ? NotFound($"User {id} not found.")
+            : Ok(new UserExistsResponse { Id = user.Id });
     }
 }

--- a/W3ChampionsIdentificationService/RolesAndPermissions/Repositories/UsersRepository.cs
+++ b/W3ChampionsIdentificationService/RolesAndPermissions/Repositories/UsersRepository.cs
@@ -1,4 +1,5 @@
-﻿using MongoDB.Driver;
+﻿using MongoDB.Bson;
+using MongoDB.Driver;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using W3ChampionsIdentificationService.RolesAndPermissions.Contracts;
@@ -40,5 +41,20 @@ public class UsersRepository(MongoClient mongoClient, IAppConfig appConfig) : Mo
         var indexKeys = Builders<User>.IndexKeys.Ascending(u => u.IdNormalized);
         var options = new CreateIndexOptions { Unique = true, Name = "IdNormalized_unique" };
         await collection.Indexes.CreateOneAsync(new CreateIndexModel<User>(indexKeys, options));
+    }
+
+    public async Task MigrateIdNormalized()
+    {
+        var rawCollection = CreateClient().GetCollection<BsonDocument>(typeof(User).Name);
+
+        var filter = Builders<BsonDocument>.Filter.Exists("IdNormalized", false);
+        var update = new[]
+        {
+            new BsonDocument("$set",
+                new BsonDocument("IdNormalized",
+                    new BsonDocument("$toLower", "$_id")))
+        };
+
+        await rawCollection.UpdateManyAsync(filter, PipelineDefinition<BsonDocument, BsonDocument>.Create(update));
     }
 }

--- a/W3ChampionsIdentificationService/RolesAndPermissions/Repositories/UsersRepository.cs
+++ b/W3ChampionsIdentificationService/RolesAndPermissions/Repositories/UsersRepository.cs
@@ -33,4 +33,12 @@ public class UsersRepository(MongoClient mongoClient, IAppConfig appConfig) : Mo
     {
         await Delete<User>(id);
     }
+
+    public async Task CreateIndex()
+    {
+        var collection = CreateCollection<User>();
+        var indexKeys = Builders<User>.IndexKeys.Ascending(u => u.IdNormalized);
+        var options = new CreateIndexOptions { Unique = true, Name = "IdNormalized_unique" };
+        await collection.Indexes.CreateOneAsync(new CreateIndexModel<User>(indexKeys, options));
+    }
 }

--- a/W3ChampionsIdentificationService/RolesAndPermissions/Repositories/UsersRepository.cs
+++ b/W3ChampionsIdentificationService/RolesAndPermissions/Repositories/UsersRepository.cs
@@ -47,7 +47,10 @@ public class UsersRepository(MongoClient mongoClient, IAppConfig appConfig) : Mo
     {
         var rawCollection = CreateClient().GetCollection<BsonDocument>(typeof(User).Name);
 
-        var filter = Builders<BsonDocument>.Filter.Exists("IdNormalized", false);
+        var filter = Builders<BsonDocument>.Filter.And(
+            Builders<BsonDocument>.Filter.Exists("IdNormalized", false),
+            Builders<BsonDocument>.Filter.Type("_id", BsonType.String)
+        );
         var update = new[]
         {
             new BsonDocument("$set",

--- a/W3ChampionsIdentificationService/RolesAndPermissions/Repositories/UsersRepository.cs
+++ b/W3ChampionsIdentificationService/RolesAndPermissions/Repositories/UsersRepository.cs
@@ -10,7 +10,8 @@ public class UsersRepository(MongoClient mongoClient, IAppConfig appConfig) : Mo
 {
     public async Task<User> GetUser(string id)
     {
-        return await LoadFirst<User>(id);
+        if (id is null) return null;
+        return await LoadFirst<User>(x => x.IdNormalized == id.ToLowerInvariant());
     }
 
     public async Task<List<User>> GetAllUsers(int? limit = 50, int? offset = 0)

--- a/W3ChampionsIdentificationService/RolesAndPermissions/User.cs
+++ b/W3ChampionsIdentificationService/RolesAndPermissions/User.cs
@@ -20,7 +20,7 @@ public class User : IIdentifiable
     }
 
     [BsonIgnoreIfNull]
-    public string IdNormalized { get; set; }
+    public string IdNormalized { get; private set; }
 
     public List<string> Roles { get; set; }
 

--- a/W3ChampionsIdentificationService/RolesAndPermissions/User.cs
+++ b/W3ChampionsIdentificationService/RolesAndPermissions/User.cs
@@ -6,8 +6,22 @@ namespace W3ChampionsIdentificationService.RolesAndPermissions;
 
 public class User : IIdentifiable
 {
+    private string _id;
+
     [BsonId]
-    public string Id { get; set; }
+    public string Id
+    {
+        get => _id;
+        set
+        {
+            _id = value;
+            IdNormalized = value?.ToLowerInvariant();
+        }
+    }
+
+    [BsonIgnoreIfNull]
+    public string IdNormalized { get; set; }
+
     public List<string> Roles { get; set; }
 
     public string BnetId { get; set; }

--- a/W3ChampionsIdentificationService/RolesAndPermissions/UserExistsResponse.cs
+++ b/W3ChampionsIdentificationService/RolesAndPermissions/UserExistsResponse.cs
@@ -1,6 +1,9 @@
+using System.Text.Json.Serialization;
+
 namespace W3ChampionsIdentificationService.RolesAndPermissions;
 
 public class UserExistsResponse
 {
+    [JsonPropertyName("id")]
     public string Id { get; set; }
 }

--- a/W3ChampionsIdentificationService/RolesAndPermissions/UserExistsResponse.cs
+++ b/W3ChampionsIdentificationService/RolesAndPermissions/UserExistsResponse.cs
@@ -1,0 +1,6 @@
+namespace W3ChampionsIdentificationService.RolesAndPermissions;
+
+public class UserExistsResponse
+{
+    public string Id { get; set; }
+}


### PR DESCRIPTION
## Summary

Surfaces the canonical-cased BattleTag from `/api/users/exists` (currently 200/empty-body / 404), and switches the lookup to an indexed query via a new `IdNormalized` field.

This is the foundational change for a coordinated rewards-correctness cleanup in `website-backend` that fixes a class of bugs caused by 218 users having casing-split records across multiple collections (e.g. `TORREN#11438` vs `torren#11438`). Without canonical resolution at this layer, downstream callers can't reconcile arbitrary-cased input back to the single source of truth.

### What changes

- `GET /api/users/exists?id=torren%2311438` now returns `200 { "id": "TORREN#11438" }` (canonical body); 404 / 400 semantics unchanged.
- New `User.IdNormalized` field (always equals `Id.ToLowerInvariant()`, maintained by a property setter on `Id`; `private set` so the invariant is enforceable).
- `UsersRepository.GetUser(id)` now queries `x.IdNormalized == id.ToLowerInvariant()` — eligible for the unique index.
- New unique index `IdNormalized_unique` on the `User` collection.
- New `MigrateIdNormalized()` backfill (aggregation-pipeline `$set: { IdNormalized: { $toLower: "$_id" } }`) wired into `MigratorHostedService.StartAsync`. Defensively filters to string-typed `_id`. Idempotent; safe on every host start.

### Pre-flight against prod (read-only)

- 116,681 Users.
- 0 non-string `_id` documents.
- 0 duplicate-lowercase collisions (so the unique index will land cleanly).
- 0 docs already have `IdNormalized` (expected — this PR ships the migration).

### Cross-repo dependency

`website-backend` consumes the new body shape via a follow-up PR (`patreon-data-correctness`); deploy order is **identification-service first**, then `website-backend`.

## Test plan

- [x] 4 controller unit tests (`UsersControllerTests`) covering canonical/non-canonical/404/400.
- [x] 3 model unit tests (`UserTests`) covering setter, null, empty string, lowercase-already.
- [x] 8 integration tests (`UsersRepoTests`) covering case-insensitive lookup, no-match, persisted IdNormalized, unique-index creation + idempotency, **actual duplicate-insert rejection** with `MongoWriteException`, migration backfill + no-overwrite + idempotency, non-string `_id` ignored, empty-string `_id` handled.
- [x] `dotnet format --verify-no-changes` clean.
- [x] `dotnet test` green: 31 passed, 39 skipped (pre-existing), 0 failed.
- [ ] Post-deploy: `curl https://identification-service.w3champions.com/api/users/exists?id=torren%2311438` returns `{ "id": "TORREN#11438" }`.