### PR TITLE
fix: canonicalize non-ASCII battletags in /api/users/exists

### DIFF
--- a/W3ChampionsIdentificationService.Tests/IntegrationTests/Migrations/MigrationsRepoTests.cs
+++ b/W3ChampionsIdentificationService.Tests/IntegrationTests/Migrations/MigrationsRepoTests.cs
@@ -1,0 +1,80 @@
+using MongoDB.Bson;
+using MongoDB.Driver;
+using NUnit.Framework;
+using System;
+using System.Threading.Tasks;
+using W3ChampionsIdentificationService.Migrations;
+
+namespace W3ChampionsIdentificationService.Tests.IntegrationTests.Migrations;
+
+public class MigrationsRepoTests : IntegrationTestBase
+{
+    [Test]
+    public async Task RunIfNeeded_FirstCall_RunsMigrationAndRecordsSentinel()
+    {
+        var repo = new MigrationsRepository(_mongoClient, _appConfig);
+        var ran = 0;
+
+        await repo.RunIfNeeded("test_v1", () => { ran++; return Task.CompletedTask; });
+
+        Assert.AreEqual(1, ran, "Migration body must run on first call.");
+
+        var sentinels = CreateClient().GetCollection<BsonDocument>("_migrations");
+        var doc = await sentinels.Find(Builders<BsonDocument>.Filter.Eq("_id", "test_v1")).FirstOrDefaultAsync();
+        Assert.IsNotNull(doc, "Sentinel must be recorded after successful run.");
+        Assert.IsTrue(doc.Contains("appliedAt"), "Sentinel must record appliedAt timestamp.");
+    }
+
+    [Test]
+    public async Task RunIfNeeded_SubsequentCall_DoesNotRunMigrationAgain()
+    {
+        var repo = new MigrationsRepository(_mongoClient, _appConfig);
+        var ran = 0;
+
+        await repo.RunIfNeeded("test_v1", () => { ran++; return Task.CompletedTask; });
+        await repo.RunIfNeeded("test_v1", () => { ran++; return Task.CompletedTask; });
+        await repo.RunIfNeeded("test_v1", () => { ran++; return Task.CompletedTask; });
+
+        Assert.AreEqual(1, ran, "Migration body must run exactly once across repeated calls.");
+    }
+
+    [Test]
+    public async Task RunIfNeeded_MigrationThrows_NoSentinelWritten_AndRetryRunsAgain()
+    {
+        var repo = new MigrationsRepository(_mongoClient, _appConfig);
+        var attempts = 0;
+
+        Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await repo.RunIfNeeded("test_v1", () =>
+            {
+                attempts++;
+                throw new InvalidOperationException("simulated mid-migration crash");
+            }));
+
+        var sentinels = CreateClient().GetCollection<BsonDocument>("_migrations");
+        var doc = await sentinels.Find(Builders<BsonDocument>.Filter.Eq("_id", "test_v1")).FirstOrDefaultAsync();
+        Assert.IsNull(doc, "Sentinel must NOT be written when migration body throws.");
+
+        // Retry on next "startup" must run the body again because no sentinel exists.
+        await repo.RunIfNeeded("test_v1", () => { attempts++; return Task.CompletedTask; });
+        Assert.AreEqual(2, attempts, "Failed migration must be retried on next call.");
+
+        var docAfter = await sentinels.Find(Builders<BsonDocument>.Filter.Eq("_id", "test_v1")).FirstOrDefaultAsync();
+        Assert.IsNotNull(docAfter, "Sentinel must be written once the retry succeeds.");
+    }
+
+    [Test]
+    public async Task RunIfNeeded_DifferentMigrationIds_RunIndependently()
+    {
+        var repo = new MigrationsRepository(_mongoClient, _appConfig);
+        var ranA = 0;
+        var ranB = 0;
+
+        await repo.RunIfNeeded("a", () => { ranA++; return Task.CompletedTask; });
+        await repo.RunIfNeeded("b", () => { ranB++; return Task.CompletedTask; });
+        await repo.RunIfNeeded("a", () => { ranA++; return Task.CompletedTask; });
+
+        Assert.AreEqual(1, ranA);
+        Assert.AreEqual(1, ranB);
+    }
+}

--- a/W3ChampionsIdentificationService.Tests/IntegrationTests/RolesAndPermissions/Repositories/UsersRepoTests.cs
+++ b/W3ChampionsIdentificationService.Tests/IntegrationTests/RolesAndPermissions/Repositories/UsersRepoTests.cs
@@ -98,6 +98,25 @@ public class UsersRepoTests : IntegrationTestBase
     }
 
     [Test]
+    public async Task GetUser_NonAsciiCaseInsensitiveMatch_ReturnsCanonicalUser()
+    {
+        // 'Ǫ' is U+01EA; ToLowerInvariant() folds to 'ǫ' U+01EB.
+        // MongoDB's $toLower aggregation operator does NOT fold this — only ASCII —
+        // so the lookup and any server-side normalization must agree on .NET semantics.
+        var userRepo = new UsersRepository(_mongoClient, _appConfig);
+        var canonical = new User { Id = "aǪua#2851", BnetId = "105550725", Roles = new List<string>() };
+        await userRepo.CreateUser(canonical);
+
+        var foundExact = await userRepo.GetUser("aǪua#2851");
+        var foundLower = await userRepo.GetUser("aǫua#2851");
+
+        Assert.IsNotNull(foundExact, "Exact-cased non-ASCII lookup must find the row.");
+        Assert.AreEqual("aǪua#2851", foundExact.Id);
+        Assert.IsNotNull(foundLower, "Already-lowercased non-ASCII lookup must find the row.");
+        Assert.AreEqual("aǪua#2851", foundLower.Id);
+    }
+
+    [Test]
     public async Task GetUser_NoMatch_ReturnsNull()
     {
         // arrange
@@ -183,19 +202,71 @@ public class UsersRepoTests : IntegrationTestBase
     }
 
     [Test]
-    public async Task MigrateIdNormalized_DoesNotOverwriteExistingField()
+    public async Task MigrateIdNormalized_LeavesAlreadyCanonicalFieldUnchanged()
     {
         var userRepo = new UsersRepository(_mongoClient, _appConfig);
         var canonical = new User { Id = "Existing#1234", BnetId = "x", Roles = new System.Collections.Generic.List<string>() };
         await userRepo.CreateUser(canonical);
-        // Setter populated IdNormalized to "existing#1234"
+        // Setter populated IdNormalized to "existing#1234".
 
         await userRepo.MigrateIdNormalized();
 
         var rawColl = CreateClient().GetCollection<MongoDB.Bson.BsonDocument>("User");
         var doc = await rawColl.Find(MongoDB.Driver.Builders<MongoDB.Bson.BsonDocument>.Filter.Eq("_id", "Existing#1234")).FirstOrDefaultAsync();
         Assert.AreEqual("existing#1234", doc["IdNormalized"].AsString,
-            "Migration should not modify already-populated IdNormalized values.");
+            "Migration must not touch IdNormalized when it already equals the canonical lowercase.");
+    }
+
+    [Test]
+    public async Task MigrateIdNormalized_RewritesStaleMixedCaseIdNormalized()
+    {
+        // Legacy shape: pre-canonicalization code copied _id verbatim into IdNormalized.
+        // The previous migration's $exists filter skipped these rows entirely, leaving
+        // them un-normalized. The new client-side migration must rewrite them.
+        var rawColl = CreateClient().GetCollection<BsonDocument>("User");
+        await rawColl.InsertOneAsync(new BsonDocument
+        {
+            { "_id", "Stale#0001" },
+            { "IdNormalized", "Stale#0001" }, // mixed-case copy of _id
+            { "BnetId", "1" },
+            { "Roles", new BsonArray() },
+        });
+
+        var userRepo = new UsersRepository(_mongoClient, _appConfig);
+        await userRepo.MigrateIdNormalized();
+
+        var doc = await rawColl.Find(Builders<BsonDocument>.Filter.Eq("_id", "Stale#0001")).FirstOrDefaultAsync();
+        Assert.AreEqual("stale#0001", doc["IdNormalized"].AsString,
+            "Migration must rewrite IdNormalized when the stored value is not the canonical lowercase of _id.");
+    }
+
+    [Test]
+    public async Task MigrateIdNormalized_RewritesStaleNonAsciiIdNormalized()
+    {
+        // The reported bug: non-ASCII battletag, IdNormalized was stored verbatim and
+        // never touched because $exists filter skipped it. .NET ToLowerInvariant of 'Ǫ'
+        // (U+01EA) is 'ǫ' (U+01EB); MongoDB's $toLower would NOT fold this. The new
+        // migration normalizes client-side and lookup succeeds.
+        var rawColl = CreateClient().GetCollection<BsonDocument>("User");
+        await rawColl.InsertOneAsync(new BsonDocument
+        {
+            { "_id", "aǪua#2851" },
+            { "IdNormalized", "aǪua#2851" }, // pre-canonicalization verbatim copy
+            { "BnetId", "105550725" },
+            { "Roles", BsonNull.Value },
+        });
+
+        var userRepo = new UsersRepository(_mongoClient, _appConfig);
+        await userRepo.MigrateIdNormalized();
+
+        var doc = await rawColl.Find(Builders<BsonDocument>.Filter.Eq("_id", "aǪua#2851")).FirstOrDefaultAsync();
+        Assert.AreEqual("aǫua#2851", doc["IdNormalized"].AsString,
+            "Migration must Unicode-fold non-ASCII chars to match GetUser's .NET-side ToLowerInvariant.");
+
+        // And the bug must be gone: lookup with the original (mixed-case) tag now succeeds.
+        var lookedUp = await userRepo.GetUser("aǪua#2851");
+        Assert.IsNotNull(lookedUp);
+        Assert.AreEqual("aǪua#2851", lookedUp.Id);
     }
 
     [Test]

--- a/W3ChampionsIdentificationService/Migrations/IMigrationsRepository.cs
+++ b/W3ChampionsIdentificationService/Migrations/IMigrationsRepository.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Threading.Tasks;
+
+namespace W3ChampionsIdentificationService.Migrations;
+
+public interface IMigrationsRepository
+{
+    // Runs `migration` if `migrationId` has not been recorded as applied.
+    // The sentinel is only written AFTER `migration` completes without throwing,
+    // so an interrupted run leaves no record and retries on next startup. The
+    // caller's migration body must therefore be idempotent at the row level.
+    Task RunIfNeeded(string migrationId, Func<Task> migration);
+}

--- a/W3ChampionsIdentificationService/Migrations/MigrationsRepository.cs
+++ b/W3ChampionsIdentificationService/Migrations/MigrationsRepository.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Threading.Tasks;
+using MongoDB.Bson;
+using MongoDB.Driver;
+using Serilog;
+using W3ChampionsIdentificationService.Config;
+
+namespace W3ChampionsIdentificationService.Migrations;
+
+// One-shot migration registry backed by a `_migrations` collection.
+//
+// Idempotency contract:
+//   1. Check the sentinel doc; if present, the migration already ran — skip.
+//   2. Otherwise execute the migration body.
+//   3. Only on success record `{ _id: migrationId, appliedAt: <utc> }`.
+//
+// If the migration throws or the process is killed before step 3, no sentinel
+// is written and the next startup re-runs it. The migration body must be
+// idempotent at the row level so a partial/resumed run converges to the
+// correct end state.
+//
+// Multi-replica races are tolerated: two pods may both see "not applied" and
+// both run the body. The second InsertOne hits the unique _id index and we
+// swallow the DuplicateKey. Work is duplicated but the result is correct.
+public class MigrationsRepository(MongoClient mongoClient, IAppConfig appConfig)
+    : MongoDbRepositoryBase(mongoClient, appConfig), IMigrationsRepository
+{
+    private const string CollectionName = "_migrations";
+
+    public async Task RunIfNeeded(string migrationId, Func<Task> migration)
+    {
+        var collection = CreateClient().GetCollection<BsonDocument>(CollectionName);
+        var filter = Builders<BsonDocument>.Filter.Eq("_id", migrationId);
+
+        if (await collection.Find(filter).AnyAsync())
+        {
+            return;
+        }
+
+        Log.Information("Running migration {MigrationId}", migrationId);
+        await migration();
+
+        try
+        {
+            await collection.InsertOneAsync(new BsonDocument
+            {
+                ["_id"] = migrationId,
+                ["appliedAt"] = DateTime.UtcNow,
+            });
+            Log.Information("Migration {MigrationId} recorded as applied", migrationId);
+        }
+        catch (MongoWriteException ex)
+            when (ex.WriteError?.Category == ServerErrorCategory.DuplicateKey)
+        {
+            // Another replica recorded it concurrently. Our run was idempotent, so this is fine.
+            Log.Information("Migration {MigrationId} already recorded by another process", migrationId);
+        }
+    }
+}

--- a/W3ChampionsIdentificationService/MigratorHostedService.cs
+++ b/W3ChampionsIdentificationService/MigratorHostedService.cs
@@ -4,6 +4,7 @@ using System;
 using System.Threading.Tasks;
 using System.Threading;
 using W3ChampionsIdentificationService.Identity.Contracts;
+using W3ChampionsIdentificationService.Migrations;
 using W3ChampionsIdentificationService.RolesAndPermissions.Contracts;
 
 namespace W3ChampionsIdentificationService;
@@ -17,7 +18,13 @@ public class MigratorHostedService(IServiceProvider serviceProvider) : IHostedSe
         await _serviceProvider.GetService<IMicrosoftIdentityRepository>().CreateIndex();
 
         var usersRepo = _serviceProvider.GetService<IUsersRepository>();
-        await usersRepo.MigrateIdNormalized();
+        var migrationsRepo = _serviceProvider.GetService<IMigrationsRepository>();
+
+        // Bump the suffix when the migration body's semantics change so the new
+        // logic runs once per cluster after the deploy lands.
+        await migrationsRepo.RunIfNeeded(
+            "IdNormalized_v2_unicode",
+            () => usersRepo.MigrateIdNormalized());
         await usersRepo.CreateIndex();
     }
 

--- a/W3ChampionsIdentificationService/RolesAndPermissions/Repositories/UsersRepository.cs
+++ b/W3ChampionsIdentificationService/RolesAndPermissions/Repositories/UsersRepository.cs
@@ -43,21 +43,60 @@ public class UsersRepository(MongoClient mongoClient, IAppConfig appConfig) : Mo
         await collection.Indexes.CreateOneAsync(new CreateIndexModel<User>(indexKeys, options));
     }
 
+    private const int MigrationBatchSize = 1000;
+
+    // Idempotent at the row level: skips docs whose IdNormalized already equals the
+    // canonical lowercase. Safe to re-run after a partial/interrupted execution —
+    // already-migrated docs are no-ops on the next pass.
+    //
+    // We re-evaluate IdNormalized client-side with .NET ToLowerInvariant() so it
+    // matches GetUser's lookup. MongoDB's $toLower only folds ASCII, which would
+    // leave non-ASCII characters (e.g. 'Ǫ' U+01EA) uppercase and break lookups for
+    // those users. We also process docs where IdNormalized exists but is stale —
+    // legacy rows written before canonicalization stored a verbatim copy of _id.
+    //
+    // Writes are flushed in batches of MigrationBatchSize to bound client memory
+    // and make progress visible to other replicas (so a crash mid-run doesn't
+    // require reprocessing everything from scratch).
     public async Task MigrateIdNormalized()
     {
         var rawCollection = CreateClient().GetCollection<BsonDocument>(typeof(User).Name);
 
-        var filter = Builders<BsonDocument>.Filter.And(
-            Builders<BsonDocument>.Filter.Exists("IdNormalized", false),
-            Builders<BsonDocument>.Filter.Type("_id", BsonType.String)
-        );
-        var update = new[]
-        {
-            new BsonDocument("$set",
-                new BsonDocument("IdNormalized",
-                    new BsonDocument("$toLower", "$_id")))
-        };
+        var filter = Builders<BsonDocument>.Filter.Type("_id", BsonType.String);
+        var projection = Builders<BsonDocument>.Projection
+            .Include("_id")
+            .Include("IdNormalized");
 
-        await rawCollection.UpdateManyAsync(filter, PipelineDefinition<BsonDocument, BsonDocument>.Create(update));
+        var bulkOps = new List<WriteModel<BsonDocument>>(MigrationBatchSize);
+
+        using var cursor = await rawCollection.FindAsync(filter,
+            new FindOptions<BsonDocument, BsonDocument> { Projection = projection });
+        while (await cursor.MoveNextAsync())
+        {
+            foreach (var doc in cursor.Current)
+            {
+                var id = doc["_id"].AsString;
+                var canonical = id.ToLowerInvariant();
+                var existing = doc.TryGetValue("IdNormalized", out var idn) && idn.IsString
+                    ? idn.AsString
+                    : null;
+                if (existing == canonical) continue;
+
+                bulkOps.Add(new UpdateOneModel<BsonDocument>(
+                    Builders<BsonDocument>.Filter.Eq("_id", id),
+                    Builders<BsonDocument>.Update.Set("IdNormalized", canonical)));
+
+                if (bulkOps.Count >= MigrationBatchSize)
+                {
+                    await rawCollection.BulkWriteAsync(bulkOps);
+                    bulkOps.Clear();
+                }
+            }
+        }
+
+        if (bulkOps.Count > 0)
+        {
+            await rawCollection.BulkWriteAsync(bulkOps);
+        }
     }
 }

--- a/W3ChampionsIdentificationService/Startup.cs
+++ b/W3ChampionsIdentificationService/Startup.cs
@@ -10,6 +10,7 @@ using W3ChampionsIdentificationService.Identity.Contracts;
 using W3ChampionsIdentificationService.Identity.Repositories;
 using W3ChampionsIdentificationService.Microsoft;
 using W3ChampionsIdentificationService.Middleware;
+using W3ChampionsIdentificationService.Migrations;
 using W3ChampionsIdentificationService.RolesAndPermissions;
 using W3ChampionsIdentificationService.RolesAndPermissions.CommandHandlers;
 using W3ChampionsIdentificationService.RolesAndPermissions.Contracts;
@@ -41,6 +42,7 @@ public class Startup
         services.AddTransient<IRolesRepository, RolesRepository>();
         services.AddTransient<IUsersRepository, UsersRepository>();
         services.AddTransient<IMicrosoftIdentityRepository, MicrosoftIdentityRepository>();
+        services.AddTransient<IMigrationsRepository, MigrationsRepository>();
 
         services.AddTransient<IPermissionsCommandHandler, PermissionsCommandHandler>();
         services.AddTransient<IRolesCommandHandler, RolesCommandHandler>();


### PR DESCRIPTION
## Summary

`GET /api/users/exists?id=aǪua%232851` returned **404** despite the row existing in the database. Two compounding bugs caused it:

1. **Lookup vs. migration use different lowercase implementations.** Lookup folds with .NET `ToLowerInvariant()` (full Unicode); the prior migration used MongoDB `$toLower`, which is **ASCII-only**. For characters like `Ǫ` (U+01EA → `ǫ` U+01EB) the write and read paths produced different `IdNormalized` values.
2. **Migration filter only backfilled missing fields.** Legacy rows pre-dating canonicalization had `IdNormalized` set to a verbatim mixed-case copy of `_id`. The `Exists("IdNormalized", false)` filter skipped them permanently.

The reported user `_id == IdNormalized == "aǪua#2851"` is exactly that legacy state.

## Fix

- Rewrite `UsersRepository.MigrateIdNormalized` to scan every string-id doc and compute the canonical lowercase **client-side** (`.NET ToLowerInvariant()`), bulk-updating only the rows whose `IdNormalized` is wrong. Batched at 1000 to bound memory; idempotent at row level so partial runs resume safely.
- Add `IMigrationsRepository.RunIfNeeded(id, body)` — a sentinel-record registry in a `_migrations` collection. The sentinel is written **after** the body completes successfully, so an interrupted migration leaves no record and retries on next startup. Multi-replica races are tolerated via the `_id` unique index plus DuplicateKey swallow.
- Gate the migration in `MigratorHostedService` behind key `IdNormalized_v2_unicode` so it runs exactly once per cluster after this deploy. Bump the suffix on future semantic changes.
- Hand-rolled rather than imported a package: every maintained Mongo migration package on NuGet now requires `MongoDB.Driver` 3.x, while this repo recently moved to 2.30.x; bumping the driver is a much larger change than the bug fix.

## Test plan

- [x] `dotnet build` clean
- [x] Full integration test suite green (42 passed, 0 failed)
- [x] New tests:
  - `GetUser_NonAsciiCaseInsensitiveMatch_ReturnsCanonicalUser` — proves the lookup contract for non-ASCII
  - `MigrateIdNormalized_RewritesStaleNonAsciiIdNormalized` — replicates the reported `aǪua#2851` row, runs migration, verifies `IdNormalized` becomes `aǫua#2851` and `GetUser("aǪua#2851")` resolves
  - `MigrateIdNormalized_RewritesStaleMixedCaseIdNormalized` — generic stale-row case
  - `MigrationsRepoTests`: 4 tests covering first-run, idempotency, throw-and-retry (no premature sentinel), and independent migration ids
- [ ] After deploy: confirm `GET /api/users/exists?id=a%C7%AAua%232851` returns `200` with the canonical battletag in the response body