### PR TITLE
feat: trust Russia gateway IP in ForwardedHeaders (prophylactic for flo-TLS-443 Phase B)

### DIFF
--- a/W3ChampionsIdentificationService/Startup.cs
+++ b/W3ChampionsIdentificationService/Startup.cs
@@ -67,7 +67,8 @@ public class Startup
         app.UseForwardedHeaders(new ForwardedHeadersOptions
         {
             ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto,
-            KnownNetworks = { new IPNetwork(IPAddress.Parse("172.18.0.0"), 16) } // Docker network
+            KnownNetworks = { new IPNetwork(IPAddress.Parse("172.18.0.0"), 16) }, // Docker network
+            KnownProxies = { IPAddress.Parse("212.60.5.180") } // Russia gateway
         });
         app.UseRouting();
         app.UseCors(builder =>


### PR DESCRIPTION
## Summary

One-line addition mirroring the same fix in website-backend (PR #518). Adds 212.60.5.180 (Russia gateway) to ForwardedHeaders.KnownProxies.

## Why

Phase B of the flo-TLS-on-443 design changes the ingress chain such that Russia's IP appears in the outbound X-Forwarded-For to this service for Russia-routed requests. Without trusting Russia in KnownProxies, .NET's middleware would resolve RemoteIpAddress to Russia's IP. No current code reads RemoteIpAddress for security logic in this service, but the fix is prophylactic — adding it now means future IP-aware logic doesn't have a latent bug.

## Phase

Part of Phase A of the rollout. **Inert today**, no behavior change.

## Test plan

- [x] \`dotnet build\` succeeds
- [x] Existing tests pass