### PR TITLE
feat: add OpenIddict OIDC Identity Provider (Quackback SSO)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,5 +23,9 @@ OIDC_SIGNING_KEY_PEM=-----BEGIN RSA PRIVATE KEY-----\nYOUR_OIDC_SIGNING_KEY_HERE
 # Encryption key — MUST be a SEPARATE key from the signing key.
 # Generate with: openssl genrsa -out oidc_enc_key.pem 2048  (then paste with \n escapes)
 OIDC_ENCRYPTION_KEY_PEM=-----BEGIN RSA PRIVATE KEY-----\nYOUR_OIDC_ENCRYPTION_KEY_HERE\n-----END RSA PRIVATE KEY-----
+# OIDC_ISSUER MUST exactly equal one of the handoff return-URL allowlist origins
+# (HandoffReturnUrlValidator.AllowedOrigins) or the SSO handoff rejects the authorize
+# return URL with HTTP 400. Use the prod or test origin:
 OIDC_ISSUER=https://identification-service.w3champions.com
+# OIDC_ISSUER=https://identification-service.test.w3champions.com
 WEBSITE_LOGIN_URL=https://w3champions.com/sso-continue

--- a/.env.example
+++ b/.env.example
@@ -16,3 +16,9 @@ JWT_PUBLIC_KEY=-----BEGIN PUBLIC KEY-----\nYOUR_PUBLIC_KEY_HERE\n-----END PUBLIC
 # Azure AD
 AAD_APP_CLIENT_ID=your-aad-client-id
 AAD_APP_CLIENT_SECRET=your-aad-client-secret
+
+# OIDC IdP
+# Generate with: openssl genrsa -out oidc_key.pem 2048  (then paste with \n escapes)
+OIDC_SIGNING_KEY_PEM=-----BEGIN RSA PRIVATE KEY-----\nYOUR_OIDC_KEY_HERE\n-----END RSA PRIVATE KEY-----
+OIDC_ISSUER=https://identification-service.w3champions.com
+WEBSITE_LOGIN_URL=https://w3champions.com/sso-continue

--- a/.env.example
+++ b/.env.example
@@ -18,7 +18,10 @@ AAD_APP_CLIENT_ID=your-aad-client-id
 AAD_APP_CLIENT_SECRET=your-aad-client-secret
 
 # OIDC IdP
-# Generate with: openssl genrsa -out oidc_key.pem 2048  (then paste with \n escapes)
-OIDC_SIGNING_KEY_PEM=-----BEGIN RSA PRIVATE KEY-----\nYOUR_OIDC_KEY_HERE\n-----END RSA PRIVATE KEY-----
+# Signing key — generate with: openssl genrsa -out oidc_key.pem 2048  (then paste with \n escapes)
+OIDC_SIGNING_KEY_PEM=-----BEGIN RSA PRIVATE KEY-----\nYOUR_OIDC_SIGNING_KEY_HERE\n-----END RSA PRIVATE KEY-----
+# Encryption key — MUST be a SEPARATE key from the signing key.
+# Generate with: openssl genrsa -out oidc_enc_key.pem 2048  (then paste with \n escapes)
+OIDC_ENCRYPTION_KEY_PEM=-----BEGIN RSA PRIVATE KEY-----\nYOUR_OIDC_ENCRYPTION_KEY_HERE\n-----END RSA PRIVATE KEY-----
 OIDC_ISSUER=https://identification-service.w3champions.com
 WEBSITE_LOGIN_URL=https://w3champions.com/sso-continue

--- a/.env.example
+++ b/.env.example
@@ -28,4 +28,9 @@ OIDC_ENCRYPTION_KEY_PEM=-----BEGIN RSA PRIVATE KEY-----\nYOUR_OIDC_ENCRYPTION_KE
 # return URL with HTTP 400. Use the prod or test origin:
 OIDC_ISSUER=https://identification-service.w3champions.com
 # OIDC_ISSUER=https://identification-service.test.w3champions.com
+# WEBSITE_LOGIN_URL must be the origin that actually serves /sso-continue. The handoff
+# login-CSRF check (HandoffOriginValidator) accepts the browser Origin only if it matches
+# this origin OR its apex/www sibling — so both https://w3champions.com and
+# https://www.w3champions.com are accepted regardless of which is set here. Any other host,
+# scheme, or port is rejected with HTTP 400.
 WEBSITE_LOGIN_URL=https://w3champions.com/sso-continue

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,8 +3,10 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
+    <PackageVersion Include="OpenIddict.AspNetCore" Version="7.5.0" />
+    <PackageVersion Include="OpenIddict.MongoDb" Version="7.5.0" />
     <PackageVersion Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="6.25.1" />
-    <PackageVersion Include="MongoDB.Driver" Version="2.30.0" />
+    <PackageVersion Include="MongoDB.Driver" Version="3.6.0" />
     <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="6.34.0" />
     <PackageVersion Include="AutoFixture" Version="4.17.0" />
     <PackageVersion Include="Moq" Version="4.17.2" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,9 +5,9 @@
   <ItemGroup>
     <PackageVersion Include="OpenIddict.AspNetCore" Version="7.5.0" />
     <PackageVersion Include="OpenIddict.MongoDb" Version="7.5.0" />
-    <PackageVersion Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="6.25.1" />
+    <PackageVersion Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.16.0" />
     <PackageVersion Include="MongoDB.Driver" Version="3.6.0" />
-    <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="6.34.0" />
+    <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.16.0" />
     <PackageVersion Include="AutoFixture" Version="4.17.0" />
     <PackageVersion Include="Moq" Version="4.17.2" />
     <PackageVersion Include="nunit" Version="3.12.0" />

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,4 +20,4 @@ COPY --from=build-env /app/out .
 ENV ASPNETCORE_URLS http://*:80
 EXPOSE 80
 
-ENTRYPOINT dotnet W3ChampionsIdentificationService.dll
+ENTRYPOINT ["dotnet", "W3ChampionsIdentificationService.dll"]

--- a/W3ChampionsIdentificationService.Tests/IntegrationTests/DataProtection/MongoXmlRepositoryTests.cs
+++ b/W3ChampionsIdentificationService.Tests/IntegrationTests/DataProtection/MongoXmlRepositoryTests.cs
@@ -1,0 +1,68 @@
+using System.Linq;
+using System.Xml.Linq;
+using MongoDB.Bson;
+using MongoDB.Driver;
+using NUnit.Framework;
+using W3ChampionsIdentificationService.DataProtection;
+
+namespace W3ChampionsIdentificationService.Tests.IntegrationTests.DataProtection;
+
+// Exercises the real Mongo-backed DataProtection key-ring repository. Uses the shared
+// IntegrationTestBase harness (live MongoDB, DB dropped in [SetUp]) so the store/read-back
+// round-trip is genuinely verified rather than mocked.
+public class MongoXmlRepositoryTests : IntegrationTestBase
+{
+    private const string CollectionName = "DataProtectionKeys";
+
+    private MongoXmlRepository CreateRepository() =>
+        new(CreateClient().GetCollection<BsonDocument>(CollectionName));
+
+    [Test]
+    public void StoreElement_ThenGetAllElements_RoundTripsTheXml()
+    {
+        var repo = CreateRepository();
+        var element = new XElement("key", new XAttribute("id", "abc"), new XElement("descriptor", "value"));
+
+        repo.StoreElement(element, friendlyName: "key-abc");
+
+        var all = repo.GetAllElements();
+        Assert.AreEqual(1, all.Count, "Exactly one stored element must be read back.");
+        Assert.AreEqual(element.ToString(SaveOptions.DisableFormatting), all.Single().ToString(SaveOptions.DisableFormatting));
+    }
+
+    [Test]
+    public void StoreElement_SameFriendlyNameTwice_Upserts_NoDuplicate()
+    {
+        var repo = CreateRepository();
+        var original = new XElement("key", new XAttribute("id", "abc"), new XElement("payload", "v1"));
+        var updated = new XElement("key", new XAttribute("id", "abc"), new XElement("payload", "v2"));
+
+        repo.StoreElement(original, friendlyName: "key-abc");
+        repo.StoreElement(updated, friendlyName: "key-abc");
+
+        var all = repo.GetAllElements();
+        Assert.AreEqual(1, all.Count, "Re-storing the same friendlyName must upsert in place, not duplicate.");
+        StringAssert.Contains("v2", all.Single().ToString(), "The latest value must win.");
+    }
+
+    [Test]
+    public void StoreElement_DistinctKeys_AllReadBack()
+    {
+        var repo = CreateRepository();
+        repo.StoreElement(new XElement("key", new XAttribute("id", "1")), friendlyName: "key-1");
+        repo.StoreElement(new XElement("key", new XAttribute("id", "2")), friendlyName: "key-2");
+
+        var all = repo.GetAllElements();
+        Assert.AreEqual(2, all.Count, "Distinct keys must each be persisted and read back.");
+    }
+
+    [Test]
+    public void StoreElement_NullFriendlyName_StillPersists()
+    {
+        var repo = CreateRepository();
+        repo.StoreElement(new XElement("key", new XAttribute("id", "x")), friendlyName: null);
+
+        var all = repo.GetAllElements();
+        Assert.AreEqual(1, all.Count, "An element with no friendlyName must still be persisted exactly once.");
+    }
+}

--- a/W3ChampionsIdentificationService.Tests/TestsAppConfig.cs
+++ b/W3ChampionsIdentificationService.Tests/TestsAppConfig.cs
@@ -7,4 +7,10 @@ public class TestsAppConfig : IAppConfig
     public string MongoConnectionString => "mongodb://157.90.1.251:3712"; // "mongodb://localhost:27017";
 
     public string DatabaseName => "W3Champions-Identification-Service-Tests";
+
+    public string OidcSigningKeyPem => "";
+
+    public string WebsiteLoginUrl => "https://localhost:3000/sso-continue";
+
+    public string OidcIssuer => "https://localhost:5050";
 }

--- a/W3ChampionsIdentificationService.Tests/TestsAppConfig.cs
+++ b/W3ChampionsIdentificationService.Tests/TestsAppConfig.cs
@@ -10,6 +10,8 @@ public class TestsAppConfig : IAppConfig
 
     public string OidcSigningKeyPem => "";
 
+    public string OidcEncryptionKeyPem => "";
+
     public string WebsiteLoginUrl => "https://localhost:3000/sso-continue";
 
     public string OidcIssuer => "https://localhost:5050";

--- a/W3ChampionsIdentificationService.Tests/UnitTests/Oidc/AuthorizeDestinationsTests.cs
+++ b/W3ChampionsIdentificationService.Tests/UnitTests/Oidc/AuthorizeDestinationsTests.cs
@@ -1,0 +1,105 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using NUnit.Framework;
+using OpenIddict.Abstractions;
+using OpenIddict.Server.AspNetCore;
+using W3ChampionsIdentificationService.Oidc;
+using static OpenIddict.Abstractions.OpenIddictConstants;
+
+namespace W3ChampionsIdentificationService.Tests.UnitTests.Oidc;
+
+/// <summary>
+/// Guards the claim/scope/destination ordering in OidcAuthorizeController.Authorize: scopes must be
+/// set BEFORE destinations so the private scope claims (oi_scp) added by SetScopes receive the
+/// access-token destination via the `_ => AccessToken` default. If destinations are assigned first,
+/// the scope claims get no destination, are dropped from the access token, and userinfo (which reads
+/// principal.GetScopes() off the access token) loses name/email.
+///
+/// This reproduces the exact principal-building sequence without an HTTP host (SetScopes /
+/// SetDestinations / GetDestinations are pure ClaimsPrincipal extensions over the claim set).
+/// </summary>
+[TestFixture]
+public class AuthorizeDestinationsTests
+{
+    private const string BattleTag = "Modmoto#2809";
+
+    private static ClaimsPrincipal BuildPrincipal(IEnumerable<string> scopes)
+    {
+        var scopeList = scopes.ToList();
+        var identity = new ClaimsIdentity(
+            OpenIddictServerAspNetCoreDefaults.AuthenticationScheme, Claims.Name, Claims.Role);
+
+        identity.AddClaim(Claims.Subject, BattleTag);
+        if (scopeList.Contains(Scopes.Profile))
+            identity.AddClaim(Claims.Name, BattleTag);
+        if (scopeList.Contains(Scopes.Email))
+        {
+            identity.AddClaim(Claims.Email, OidcClaimMapper.BattleTagToSyntheticEmail(BattleTag));
+            identity.AddClaim(new Claim(Claims.EmailVerified, "false", ClaimValueTypes.Boolean));
+        }
+
+        var principal = new ClaimsPrincipal(identity);
+        // Same order as the controller: scopes first, then destinations over all claims.
+        principal.SetScopes(scopeList);
+        principal.SetDestinations(claim => claim.Type switch
+        {
+            Claims.Subject => new[] { Destinations.AccessToken, Destinations.IdentityToken },
+            Claims.Name => new[] { Destinations.IdentityToken },
+            Claims.Email => new[] { Destinations.IdentityToken },
+            Claims.EmailVerified => new[] { Destinations.IdentityToken },
+            _ => new[] { Destinations.AccessToken }
+        });
+        return principal;
+    }
+
+    [Test]
+    public void ScopeClaim_CarriesAccessTokenDestination()
+    {
+        var principal = BuildPrincipal(new[] { Scopes.OpenId, Scopes.Profile, Scopes.Email });
+
+        // The scope claims SetScopes adds must each route to the access token, so the access token
+        // carries the granted scopes and userinfo can read them back.
+        var scopeClaims = principal.Claims.Where(c => c.Value is Scopes.OpenId or Scopes.Profile or Scopes.Email).ToList();
+        Assert.IsNotEmpty(scopeClaims, "Expected SetScopes to add scope claims to the principal.");
+        foreach (var scopeClaim in scopeClaims)
+        {
+            Assert.Contains(Destinations.AccessToken, scopeClaim.GetDestinations().ToArray(),
+                $"Scope claim '{scopeClaim.Value}' must carry the AccessToken destination.");
+        }
+    }
+
+    [Test]
+    public void GrantedScopes_AreReadableFromThePrincipal()
+    {
+        var principal = BuildPrincipal(new[] { Scopes.OpenId, Scopes.Profile, Scopes.Email });
+
+        // This is exactly what OidcUserInfoController reads to gate name/email.
+        var scopes = principal.GetScopes();
+        Assert.Contains(Scopes.Profile, scopes.ToArray(), "profile scope must be readable from the access-token principal.");
+        Assert.Contains(Scopes.Email, scopes.ToArray(), "email scope must be readable from the access-token principal.");
+    }
+
+    [Test]
+    public void Subject_CarriesBothAccessAndIdentityTokenDestinations()
+    {
+        var principal = BuildPrincipal(new[] { Scopes.OpenId, Scopes.Profile });
+
+        var sub = principal.Claims.Single(c => c.Type == Claims.Subject);
+        var destinations = sub.GetDestinations().ToArray();
+        Assert.Contains(Destinations.AccessToken, destinations, "sub must reach the access token.");
+        Assert.Contains(Destinations.IdentityToken, destinations, "sub must reach the id token.");
+    }
+
+    [Test]
+    public void NameAndEmail_StayIdentityTokenOnly()
+    {
+        var principal = BuildPrincipal(new[] { Scopes.OpenId, Scopes.Profile, Scopes.Email });
+
+        var name = principal.Claims.Single(c => c.Type == Claims.Name);
+        var email = principal.Claims.Single(c => c.Type == Claims.Email);
+
+        CollectionAssert.AreEquivalent(new[] { Destinations.IdentityToken }, name.GetDestinations().ToArray());
+        CollectionAssert.AreEquivalent(new[] { Destinations.IdentityToken }, email.GetDestinations().ToArray());
+    }
+}

--- a/W3ChampionsIdentificationService.Tests/UnitTests/Oidc/ExistingOauthEndpointsRegressionTests.cs
+++ b/W3ChampionsIdentificationService.Tests/UnitTests/Oidc/ExistingOauthEndpointsRegressionTests.cs
@@ -202,10 +202,10 @@ public class ExistingOauthEndpointsRegressionTests
         var root = doc.RootElement;
 
         Assert.IsTrue(root.TryGetProperty("battleTag", out _), "battleTag claim must be present");
-        Assert.IsTrue(root.TryGetProperty("isAdmin", out _),   "isAdmin claim must be present");
-        Assert.IsTrue(root.TryGetProperty("name", out _),      "name claim must be present");
-        Assert.IsTrue(root.TryGetProperty("permissions", out _),"permissions claim must be present");
-        Assert.IsTrue(root.TryGetProperty("bnetId", out _),    "bnetId claim must be present");
+        Assert.IsTrue(root.TryGetProperty("isAdmin", out _), "isAdmin claim must be present");
+        Assert.IsTrue(root.TryGetProperty("name", out _), "name claim must be present");
+        Assert.IsTrue(root.TryGetProperty("permissions", out _), "permissions claim must be present");
+        Assert.IsTrue(root.TryGetProperty("bnetId", out _), "bnetId claim must be present");
     }
 
     [Test]

--- a/W3ChampionsIdentificationService.Tests/UnitTests/Oidc/ExistingOauthEndpointsRegressionTests.cs
+++ b/W3ChampionsIdentificationService.Tests/UnitTests/Oidc/ExistingOauthEndpointsRegressionTests.cs
@@ -79,6 +79,29 @@ public class ExistingOauthEndpointsRegressionTests
         return JsonDocument.Parse(json);
     }
 
+    // ── env hygiene ────────────────────────────────────────────────────────
+
+    private string _originalJwtPublicKey;
+
+    [SetUp]
+    public void SetUp()
+    {
+        // Capture and override JWT_PUBLIC_KEY so GetUserInfo validates against
+        // our test key pair.  NOTE: AuthorizationController.JwtPublicKey is a
+        // static readonly field captured on first type access — the ordering
+        // assumption (env set before the type is first touched) still holds.
+        // Restoring on teardown is hygiene so the override does not leak to
+        // other tests / fixtures in the same process.
+        _originalJwtPublicKey = Environment.GetEnvironmentVariable("JWT_PUBLIC_KEY");
+        Environment.SetEnvironmentVariable("JWT_PUBLIC_KEY", PublicKey);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        Environment.SetEnvironmentVariable("JWT_PUBLIC_KEY", _originalJwtPublicKey);
+    }
+
     // ── Group A — response-shape regression ───────────────────────────────
 
     [Test]
@@ -87,10 +110,6 @@ public class ExistingOauthEndpointsRegressionTests
         // Arrange — mint a real w3c JWT using the same key pair as JwtTests
         var permissions = new List<string> { nameof(EPermission.Permissions), nameof(EPermission.Moderation) };
         var auth = W3CUserAuthentication.Create("TestPlayer#9999", PrivateKey, permissions);
-
-        // Set the env var BEFORE the static field on AuthorizationController is
-        // initialised (this is the first access to the type in this test run).
-        Environment.SetEnvironmentVariable("JWT_PUBLIC_KEY", PublicKey);
 
         var controller = new AuthorizationController(
             Mock.Of<IBlizzardAuthenticationService>(),
@@ -148,6 +167,27 @@ public class ExistingOauthEndpointsRegressionTests
             JsonValueKind.Number, expEl.ValueKind,
             "exp must be a numeric epoch, not an ISO string; " +
             "this guards against IdentityModel changing the serialisation format");
+    }
+
+    [Test]
+    public void MintedJwt_Payload_IsAdminIsJsonString()
+    {
+        // Guard: today the code emits isAdmin via isAdmin.ToString() with no
+        // JsonClaimValueTypes annotation, so it serialises as a JSON STRING
+        // ("True"/"False") — NOT a JSON boolean.  Consumers parse it with
+        // Boolean.Parse on the string value, so this shape must not silently
+        // flip to a JSON boolean if a future IdentityModel/serialiser changes
+        // claim handling.
+        var auth = W3CUserAuthentication.Create("TestPlayer#9999", PrivateKey, new List<string> { "Permissions" });
+
+        using var doc = DecodePayload(auth.JWT);
+        Assert.IsTrue(
+            doc.RootElement.TryGetProperty("isAdmin", out var isAdminEl),
+            "JWT payload must contain 'isAdmin' claim");
+        Assert.AreEqual(
+            JsonValueKind.String, isAdminEl.ValueKind,
+            "isAdmin must be a JSON string ('True'/'False'), not a JSON boolean; " +
+            "this locks the current byte-compat shape consumers depend on");
     }
 
     [Test]

--- a/W3ChampionsIdentificationService.Tests/UnitTests/Oidc/ExistingOauthEndpointsRegressionTests.cs
+++ b/W3ChampionsIdentificationService.Tests/UnitTests/Oidc/ExistingOauthEndpointsRegressionTests.cs
@@ -1,0 +1,221 @@
+// ============================================================
+// MIGRATION-SAFETY LOCK — DO NOT WEAKEN
+//
+// This test file pins the observable contract of the existing
+// /api/oauth/* endpoints and the w3c JWT format after the
+// OpenIddict 7.5.0 + Microsoft.IdentityModel.* 8.16.0 +
+// MongoDB.Driver 3.6.0 upgrades that ship with PR1.
+//
+// The IdentityModel 6→8 bump switched JWT JSON serialization
+// from Newtonsoft.Json to System.Text.Json.  The two test
+// groups below guard against that change silently altering:
+//
+//   (A) RESPONSE-SHAPE: /api/oauth/user-info still returns
+//       OkObjectResult<W3CUserAuthentication> with the
+//       expected BattleTag / Name / IsAdmin values.
+//
+//   (B) TOKEN-PAYLOAD BYTE-COMPAT: the minted JWT's base64url
+//       payload (the signed bytes external consumers verify)
+//       must retain:
+//         • "permissions"  → JSON Array  (not a string)
+//         • "exp"          → JSON Number (numeric epoch, not ISO)
+//         • "battleTag", "isAdmin", "name", "bnetId" present
+//         • "iss", "aud", "jti" ABSENT  (w3c JWT non-breaking
+//           invariant — adding these would break every consumer
+//           that validates the signature over the exact payload)
+//         • "iat", "nbf"   ABSENT  (JwtSecurityToken without an
+//           explicit issuer/audience does not emit these; locking
+//           prevents a future IdentityModel release from silently
+//           adding them to the signed payload)
+// ============================================================
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Text.Json;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using NUnit.Framework;
+using W3ChampionsIdentificationService.Blizzard;
+using W3ChampionsIdentificationService.Identity.Contracts;
+using W3ChampionsIdentificationService.Microsoft;
+using W3ChampionsIdentificationService.RolesAndPermissions;
+using W3ChampionsIdentificationService.RolesAndPermissions.Contracts;
+using W3ChampionsIdentificationService.Twitch;
+using W3ChampionsIdentificationService.W3CAuthentication;
+
+namespace W3ChampionsIdentificationService.Tests.UnitTests.Oidc;
+
+/// <summary>
+/// Regression guard for the existing /api/oauth/* JWT issuance path.
+/// See the file header for the full rationale.
+/// </summary>
+[TestFixture]
+public class ExistingOauthEndpointsRegressionTests
+{
+    // ── key material (same format as JwtTests.cs) ─────────────────────────
+    private const string PrivateKey =
+        "-----BEGIN RSA PRIVATE KEY-----\nMIIJKQIBAAKCAgEA3l8idcfxcViOdQ4nZZwXsP6l42CTQmTyPT3jSOhFvm+YvK0b\nvoHw16ITYYg9CYni/aDzi8oulrI65cr8xFKgcojZnnbTDJk9YLLUznwxBtqub7MN\nF89t1+pfUgUp2H3zGzoDSl31A205mwBDRXOd5Zn97Fi8268Doy2/kIYKgycd7BaC\n+MqdecJ0KRZMpWbsA5QOewK4zmQyf6hlGLPpBNYkE7n2vg3RxeVsw1duEfD39Zh6\nkBAuTLTJDTxuDXlSuf8vH8NvPQ3ROTGl6cSHz8YOUz2em5L8wIYAW8W0tAamOTw9\nT2wEHEFpy2qpOuYWXtk3v0x3sfplBuzm8LE/DusuSyipoS0ZJJQGsOA/G2oaOFwR\new5q9M+NxlpCFJEuSNHKi609W+FjX04sxovxuEjyp9RNeQ8BSeiad5kSXDLSs9Di\nntn8oulzil5pA+ccJ8PldJYRqrTjx+lB+STOnsgtg1esTDVXn6HOva857LVv2AN5\nsT8siXTBcXRXLjDxWWoI5N3xrf4Vbh+p6P0cWoXB7puyt3IKb68Rk0DcTC5WW1vh\n4neVslL8uhxwprS7J3NvBqY4ds/zfHj+3q2PvDEX2DOgXidjIQjlIdjF0S+FzZ8w\nJd3LEcPXjDhqefdOSQDdG2G7dqBrDKTDpEQt2+Rj5s0owdQbrCEuvFe92jECAwEA\nAQKCAgEAxkmgydPzqPWleh2X5dRNj+dSdzGbvl2TYCa6cD2mS0zprnzSO4tU/oMo\nsxSwELxiq3UFFwa/imL9gAEEae+f4OHE47fjM93FTF/KwSEe+pSvbS0FJNEzipAU\nVWgDS2fsCsAtRPgJTffsoRmX4utYxe8N7N2n8mDaZnyZ0D6mSxLrbKUaPs01pOhP\nen/G8sqW9A3m56uirW/NU+YN1/w9cbGd0/VEX26lOsj8tidVICx2fwprZ+D12DJx\nARt8qwkfSnmRRMqZe6DBizWJU62KySw7g+BzeRiVxvr2gN8H5mvzdyAPL64K8EMo\nGlpO8xVOp18chbmjFhJIWeePetsidPpLtvCHy/O3jeB+jcq5hKhsAG7PFYzmrwOu\nnh/v0nAh0XcSodxaCXuq3DzHjXz2l3yqIRULZ2w7776elyqIWi6SxfTgSy+UtswK\n1VT682JLwgDq7CKi9FdfpJ2h8ap1FZmUPGxZgg2pCF9soVIbvqmsPqcRBgo1Q1G0\nb9P+FjNIWx9shjfAq38shMWR95PWKXM0Zme0qzwlf04GWURFRF+LzFonvp0+6iyR\nSMtM1+eXkD9ESwYrFhJM6rbbyYLsPPieDE3yP5eDiq3OoPiNGoqcvOc3NDb6WyW0\nC/nEEtiriT3RHuN71p88jDd3psHMjT0Isqpwe8oOE3ScB/PcN70CggEBAPguDAPA\nnoxDG6k0KooEeZSEH2hV0cRlgxGnEJ/I+VvcEeHEyvxl9duZbnUbyHWoD0zi0HxX\nefSjiJShR9FqvfTb6CcxoQyJnyFwod1/FQUb9fYcygvsOig1QOHrQKDjetfIHRxM\nu4lyamVzc8pEZ4KIJRh17A1uAbpl28sDev+Jbf2uc+LPCSt64hVaJWRH9lT/MZhF\ngxhTJr9LINqqrdEho4RERU3dH1Q9FzACYsv58eG1LY+BSts9SQkX7dCX2ZRto8Oz\nGECZBk7yGBmT1KD9aCU72BoN8ovLJEItx0T2/r39j2AZRKHh301HPkzQVklggNIt\nCGsbX/eqIMqE+88CggEBAOVg54Rp4dCnIzSL7NeuCvBurl89iE2SrAiIBfUT1CZy\noPHw1eAoN7Ua0ieFJfdTNli8ZUMmmPzROFfUzVDYYnbWieJ/lPqVWlkd/xYpLL69\nirbzyfbAJpKCEGU8OJKbnlKF51XhfjcRWfqBwZHzOdHE7ak28KYyoLy2ErWNvhhD\nVcyY7+MGWSS7Vzj5qpfamhM35VG0LyfkS0GN7lZ7hqBRB9d1Iir69N6bGJAfoKiT\ni9Q/eUGDi3uVMnhQq5fq3K5kqZ6HrwmvXlgmexly/YstDtCAh8oqwoz6uQ6Y/JGF\nAtwUe9oyJrs45UV9qLCtks+BuD5nrx0BqFvB4+g3Sf8CggEAXWNOaBcSUitqfDhC\nDZ9zdJxnCSbKAYJFWN4p1kaU9qkQHYmk7Gcdpd3Nf8nNm+B6qW7sDu4H2TO0UGGE\nGdx10G7zo9P8CzC6LaYpcqTAbyS/YDYjHWtt0vV/DcQtlJ0k+4+0zJJfO3BPcw+H\nscQdwzOh6dtt0PvlMJPlqjYMEZ5QQlZkCyPnCnJ6IpjCW0LtAbzpl6gIlZ2she0q\nVr5FG93xnvLltVAQ2u0GDa3IKYNLLqizlT2MwoUEN6TGe2i4mi7LofeBl8U9Z3WX\n9f/30gCpMOGdBujarRnq8fAx/NSItUt1qS648cWB9p1pZxQ6c/AZaX1CnrM1YIen\nQS3bZwKCAQA+or+VwPQQ7hMG/k6mdrg1/4NOLpdR14NysPIvgkKkXRjl+EXu+Ax+\nP9yzPgCoEOj+QjPEqn2MS/V+xnVqZiw9F0h/uScNZktNmotVmdjGHSwL2XaFEuN1\njl67xj4MisIo9re9E95LW0mexl/9YtWfGo9rbb05JQoPfgiN2y7VoU2EmR6od8tP\n5Hhk7ohO/zqjlNfh/7oAwq5qMD+tDf4tOPNTOoEiC3VidCe482oDnobIZqzN3wXv\nsUYe5Kh2y4OHe6V1zMdXdbPljlx/Do99ucgZ1389DYAizzRJcC1H73Jgdpd7dcZt\nyZOR7kZqOHumfl25bMa8vP8kT0XU24QxAoIBAQDX+tr00PHCiT6sf9m4v8T//3lO\nOlX776E9N7QCXMOFrNlFVZ/lF6tYsmHX2P8AjRBynC98bkilAPiQSLy6dY1GPPxJ\nN+o1jdK+RiTiNiKjdaQE9Y2akvB7n/lOPskuTsPElKUYhE7HTl9rZ2jxcT3vxau7\nc1ObhUK0cyAAMs5JOefyM3j7zwmJCcTVUDP24cJasp0+lhJhZraoPVEvYCQC9YlX\n5XjIamImUs3ZWdSpjkKuyntE5xARJLU4n6d4/u10BcN6boemzxdSkd0S8ljih0Vn\n7/Jy+u7aWFa2uAK/LVQiud7RGzn8O1LFal3HjSzsUPHz6zEM9McCU1ylrV7/\n-----END RSA PRIVATE KEY-----\n";
+
+    private const string PublicKey =
+        "-----BEGIN PUBLIC KEY-----\nMIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEA3l8idcfxcViOdQ4nZZwX\nsP6l42CTQmTyPT3jSOhFvm+YvK0bvoHw16ITYYg9CYni/aDzi8oulrI65cr8xFKg\ncojZnnbTDJk9YLLUznwxBtqub7MNF89t1+pfUgUp2H3zGzoDSl31A205mwBDRXOd\n5Zn97Fi8268Doy2/kIYKgycd7BaC+MqdecJ0KRZMpWbsA5QOewK4zmQyf6hlGLPp\nBNYkE7n2vg3RxeVsw1duEfD39Zh6kBAuTLTJDTxuDXlSuf8vH8NvPQ3ROTGl6cSH\nz8YOUz2em5L8wIYAW8W0tAamOTw9T2wEHEFpy2qpOuYWXtk3v0x3sfplBuzm8LE/\nDusuSyipoS0ZJJQGsOA/G2oaOFwRew5q9M+NxlpCFJEuSNHKi609W+FjX04sxovx\nuEjyp9RNeQ8BSeiad5kSXDLSs9Dintn8oulzil5pA+ccJ8PldJYRqrTjx+lB+STO\nnsgtg1esTDVXn6HOva857LVv2AN5sT8siXTBcXRXLjDxWWoI5N3xrf4Vbh+p6P0c\nWoXB7puyt3IKb68Rk0DcTC5WW1vh4neVslL8uhxwprS7J3NvBqY4ds/zfHj+3q2P\nvDEX2DOgXidjIQjlIdjF0S+FzZ8wJd3LEcPXjDhqefdOSQDdG2G7dqBrDKTDpEQt\n2+Rj5s0owdQbrCEuvFe92jECAwEAAQ==\n-----END PUBLIC KEY-----\n";
+
+    // ── helper ─────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Decodes the payload segment of a JWT and returns the parsed JSON document.
+    /// The caller is responsible for disposing the document.
+    /// </summary>
+    private static JsonDocument DecodePayload(string jwt)
+    {
+        var parts = jwt.Split('.');
+        Assert.AreEqual(3, parts.Length, "Expected a three-part JWT (header.payload.signature)");
+        // Base64url → standard base64
+        var base64 = parts[1].Replace('-', '+').Replace('_', '/');
+        // Pad to 4-byte boundary
+        base64 = base64.PadRight(base64.Length + (4 - base64.Length % 4) % 4, '=');
+        var bytes = Convert.FromBase64String(base64);
+        var json = Encoding.UTF8.GetString(bytes);
+        return JsonDocument.Parse(json);
+    }
+
+    // ── Group A — response-shape regression ───────────────────────────────
+
+    [Test]
+    public void GetUserInfo_ReturnsOkWithExpectedW3CUserAuthentication()
+    {
+        // Arrange — mint a real w3c JWT using the same key pair as JwtTests
+        var permissions = new List<string> { nameof(EPermission.Permissions), nameof(EPermission.Moderation) };
+        var auth = W3CUserAuthentication.Create("TestPlayer#9999", PrivateKey, permissions);
+
+        // Set the env var BEFORE the static field on AuthorizationController is
+        // initialised (this is the first access to the type in this test run).
+        Environment.SetEnvironmentVariable("JWT_PUBLIC_KEY", PublicKey);
+
+        var controller = new AuthorizationController(
+            Mock.Of<IBlizzardAuthenticationService>(),
+            Mock.Of<ITwitchAuthenticationService>(),
+            Mock.Of<IMicrosoftAuthenticationService>(),
+            Mock.Of<IUsersRepository>(),
+            Mock.Of<IRolesRepository>(),
+            Mock.Of<IPermissionsRepository>(),
+            Mock.Of<IMicrosoftIdentityRepository>());
+
+        // Act
+        var result = controller.GetUserInfo(auth.JWT);
+
+        // Assert — response shape
+        var ok = result as OkObjectResult;
+        Assert.IsNotNull(ok, "Expected 200 OK, got {0}", result?.GetType().Name);
+
+        var body = ok.Value as W3CUserAuthentication;
+        Assert.IsNotNull(body, "Response body must be W3CUserAuthentication");
+        Assert.AreEqual("TestPlayer#9999", body.BattleTag, "BattleTag must round-trip unchanged");
+        Assert.AreEqual("TestPlayer", body.Name, "Name must be the portion before '#'");
+        Assert.IsTrue(body.IsAdmin, "IsAdmin must be true when permissions are non-empty");
+    }
+
+    // ── Group B — token payload byte-compatibility ─────────────────────────
+
+    [Test]
+    public void MintedJwt_Payload_PermissionsIsJsonArray()
+    {
+        // Guard: IdentityModel 8.x must NOT serialise the array claim as a string
+        var permissions = new List<string> { "Permissions", "Moderation" };
+        var auth = W3CUserAuthentication.Create("TestPlayer#9999", PrivateKey, permissions);
+
+        using var doc = DecodePayload(auth.JWT);
+        Assert.IsTrue(
+            doc.RootElement.TryGetProperty("permissions", out var permEl),
+            "JWT payload must contain 'permissions' claim");
+        Assert.AreEqual(
+            JsonValueKind.Array, permEl.ValueKind,
+            "permissions must be a JSON array — not a serialised string; " +
+            "JsonClaimValueTypes.JsonArray must survive the IdentityModel 6→8 upgrade");
+    }
+
+    [Test]
+    public void MintedJwt_Payload_ExpIsNumericEpoch()
+    {
+        // Guard: exp must be a JSON number (Unix epoch), not an ISO-8601 string
+        var auth = W3CUserAuthentication.Create("TestPlayer#9999", PrivateKey, new List<string>());
+
+        using var doc = DecodePayload(auth.JWT);
+        Assert.IsTrue(
+            doc.RootElement.TryGetProperty("exp", out var expEl),
+            "JWT payload must contain 'exp' claim");
+        Assert.AreEqual(
+            JsonValueKind.Number, expEl.ValueKind,
+            "exp must be a numeric epoch, not an ISO string; " +
+            "this guards against IdentityModel changing the serialisation format");
+    }
+
+    [Test]
+    public void MintedJwt_Payload_ContainsExpectedClaims()
+    {
+        // Guard: all claims that downstream consumers depend on must be present
+        var permissions = new List<string> { "Permissions" };
+        var bnetId = 123456789L;
+        var auth = W3CUserAuthentication.Create("TestPlayer#9999", PrivateKey, permissions, bnetId);
+
+        using var doc = DecodePayload(auth.JWT);
+        var root = doc.RootElement;
+
+        Assert.IsTrue(root.TryGetProperty("battleTag", out _), "battleTag claim must be present");
+        Assert.IsTrue(root.TryGetProperty("isAdmin", out _),   "isAdmin claim must be present");
+        Assert.IsTrue(root.TryGetProperty("name", out _),      "name claim must be present");
+        Assert.IsTrue(root.TryGetProperty("permissions", out _),"permissions claim must be present");
+        Assert.IsTrue(root.TryGetProperty("bnetId", out _),    "bnetId claim must be present");
+    }
+
+    [Test]
+    public void MintedJwt_Payload_AbsenceOfIssuanceAndAudienceClaims()
+    {
+        // Guard: the w3c JWT non-breaking invariant — the payload must NOT gain
+        // iss, aud, or jti.  Adding these would change the signed bytes and
+        // break every external consumer that validates the signature.
+        var auth = W3CUserAuthentication.Create("TestPlayer#9999", PrivateKey, new List<string>());
+
+        using var doc = DecodePayload(auth.JWT);
+        var root = doc.RootElement;
+
+        Assert.IsFalse(root.TryGetProperty("iss", out _), "iss must NOT be present in the w3c JWT");
+        Assert.IsFalse(root.TryGetProperty("aud", out _), "aud must NOT be present in the w3c JWT");
+        Assert.IsFalse(root.TryGetProperty("jti", out _), "jti must NOT be present in the w3c JWT");
+    }
+
+    [Test]
+    public void MintedJwt_Payload_AbsenceOfIatAndNbf()
+    {
+        // Guard: JwtSecurityToken (without an explicit issuer/audience) does not
+        // auto-inject iat or nbf.  Locking this prevents a future IdentityModel
+        // release from silently altering the signed payload bytes.
+        var auth = W3CUserAuthentication.Create("TestPlayer#9999", PrivateKey, new List<string>());
+
+        using var doc = DecodePayload(auth.JWT);
+        var root = doc.RootElement;
+
+        Assert.IsFalse(root.TryGetProperty("iat", out _), "iat must NOT be present (auto-injected by IdentityModel would change signed bytes)");
+        Assert.IsFalse(root.TryGetProperty("nbf", out _), "nbf must NOT be present (auto-injected by IdentityModel would change signed bytes)");
+    }
+
+    [Test]
+    public void MintedJwt_Payload_PermissionsValuesMatchInput()
+    {
+        // Guard: verify the actual array element values round-trip correctly
+        var permissions = new List<string> { "Permissions", "Moderation", "Tournaments" };
+        var auth = W3CUserAuthentication.Create("TestPlayer#9999", PrivateKey, permissions);
+
+        using var doc = DecodePayload(auth.JWT);
+        doc.RootElement.TryGetProperty("permissions", out var permEl);
+
+        var actual = new List<string>();
+        foreach (var element in permEl.EnumerateArray())
+        {
+            actual.Add(element.GetString());
+        }
+
+        CollectionAssert.AreEquivalent(permissions, actual,
+            "Permission array elements must round-trip unchanged through the JWT payload");
+    }
+}

--- a/W3ChampionsIdentificationService.Tests/UnitTests/Oidc/HandoffJwtValidatorTests.cs
+++ b/W3ChampionsIdentificationService.Tests/UnitTests/Oidc/HandoffJwtValidatorTests.cs
@@ -101,4 +101,17 @@ public class HandoffJwtValidatorTests
         Assert.Throws<HandoffValidationException>(() =>
             validator.ValidateAndExtractBattleTag(jwt));
     }
+
+    [TestCase(null, TestName = "Null_input")]
+    [TestCase("", TestName = "Empty_input")]
+    [TestCase("   ", TestName = "Whitespace_input")]
+    [TestCase("not-a-jwt", TestName = "Garbage_single_segment")]
+    [TestCase("aaa.bbb", TestName = "Two_segments")]
+    [TestCase("a.b.c", TestName = "Three_invalid_base64url_segments")]
+    public void MalformedToken_ThrowsHandoffValidationException(string jwt)
+    {
+        var validator = new HandoffJwtValidator(_publicPem);
+        Assert.Throws<HandoffValidationException>(() =>
+            validator.ValidateAndExtractBattleTag(jwt));
+    }
 }

--- a/W3ChampionsIdentificationService.Tests/UnitTests/Oidc/HandoffJwtValidatorTests.cs
+++ b/W3ChampionsIdentificationService.Tests/UnitTests/Oidc/HandoffJwtValidatorTests.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using System.Security.Cryptography;
@@ -22,7 +21,7 @@ public class HandoffJwtValidatorTests
     {
         _testRsa = RSA.Create(2048);
         _privatePem = _testRsa.ExportRSAPrivateKeyPem();
-        _publicPem  = _testRsa.ExportSubjectPublicKeyInfoPem();
+        _publicPem = _testRsa.ExportSubjectPublicKeyInfoPem();
         _wrongRsa = RSA.Create(2048);
         _wrongPublicPem = _wrongRsa.ExportSubjectPublicKeyInfoPem();
     }

--- a/W3ChampionsIdentificationService.Tests/UnitTests/Oidc/HandoffJwtValidatorTests.cs
+++ b/W3ChampionsIdentificationService.Tests/UnitTests/Oidc/HandoffJwtValidatorTests.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Collections.Generic;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Security.Cryptography;
+using Microsoft.IdentityModel.Tokens;
+using NUnit.Framework;
+using W3ChampionsIdentificationService.Oidc;
+
+namespace W3ChampionsIdentificationService.Tests.UnitTests.Oidc;
+
+[TestFixture]
+public class HandoffJwtValidatorTests
+{
+    private static readonly RSA _testRsa;
+    private static readonly string _privatePem;
+    private static readonly string _publicPem;
+    private static readonly RSA _wrongRsa;
+    private static readonly string _wrongPublicPem;
+
+    static HandoffJwtValidatorTests()
+    {
+        _testRsa = RSA.Create(2048);
+        _privatePem = _testRsa.ExportRSAPrivateKeyPem();
+        _publicPem  = _testRsa.ExportSubjectPublicKeyInfoPem();
+        _wrongRsa = RSA.Create(2048);
+        _wrongPublicPem = _wrongRsa.ExportSubjectPublicKeyInfoPem();
+    }
+
+    private static string MakeJwt(string battleTag, TimeSpan? ttl = null, RSA signingKey = null)
+    {
+        var rsa = signingKey ?? _testRsa;
+        var creds = new SigningCredentials(
+            new RsaSecurityKey(rsa),
+            SecurityAlgorithms.RsaSha256)
+        {
+            CryptoProviderFactory = new CryptoProviderFactory { CacheSignatureProviders = false }
+        };
+        var expires = DateTime.UtcNow.Add(ttl ?? TimeSpan.FromMinutes(10));
+        var token = new JwtSecurityToken(
+            claims: new[] { new Claim("battleTag", battleTag) },
+            expires: expires,
+            signingCredentials: creds);
+        return new JwtSecurityTokenHandler().WriteToken(token);
+    }
+
+    [Test]
+    public void ValidToken_ReturnsBattleTag()
+    {
+        var validator = new HandoffJwtValidator(_publicPem);
+        var jwt = MakeJwt("Modmoto#2809");
+        var result = validator.ValidateAndExtractBattleTag(jwt);
+        Assert.AreEqual("Modmoto#2809", result);
+    }
+
+    [Test]
+    public void ExpiredToken_ThrowsHandoffValidationException()
+    {
+        var validator = new HandoffJwtValidator(_publicPem);
+        var jwt = MakeJwt("Modmoto#2809", ttl: TimeSpan.FromSeconds(-1));
+        Assert.Throws<HandoffValidationException>(() =>
+            validator.ValidateAndExtractBattleTag(jwt));
+    }
+
+    [Test]
+    public void ForgedToken_WrongKey_ThrowsHandoffValidationException()
+    {
+        var validator = new HandoffJwtValidator(_publicPem);
+        var jwt = MakeJwt("Modmoto#2809", signingKey: _wrongRsa);
+        Assert.Throws<HandoffValidationException>(() =>
+            validator.ValidateAndExtractBattleTag(jwt));
+    }
+
+    [Test]
+    public void TamperedToken_ThrowsHandoffValidationException()
+    {
+        var validator = new HandoffJwtValidator(_publicPem);
+        var jwt = MakeJwt("Modmoto#2809");
+        var parts = jwt.Split('.');
+        var sig = parts[2].ToCharArray();
+        sig[0] = sig[0] == 'A' ? 'B' : 'A';
+        var tampered = $"{parts[0]}.{parts[1]}.{new string(sig)}";
+        Assert.Throws<HandoffValidationException>(() =>
+            validator.ValidateAndExtractBattleTag(tampered));
+    }
+
+    [Test]
+    public void TokenMissingBattleTagClaim_ThrowsHandoffValidationException()
+    {
+        var creds = new SigningCredentials(
+            new RsaSecurityKey(_testRsa), SecurityAlgorithms.RsaSha256)
+        {
+            CryptoProviderFactory = new CryptoProviderFactory { CacheSignatureProviders = false }
+        };
+        var token = new JwtSecurityToken(
+            claims: new[] { new Claim("sub", "someuser") },
+            expires: DateTime.UtcNow.AddMinutes(10),
+            signingCredentials: creds);
+        var jwt = new JwtSecurityTokenHandler().WriteToken(token);
+        var validator = new HandoffJwtValidator(_publicPem);
+        Assert.Throws<HandoffValidationException>(() =>
+            validator.ValidateAndExtractBattleTag(jwt));
+    }
+}

--- a/W3ChampionsIdentificationService.Tests/UnitTests/Oidc/HandoffOriginValidatorTests.cs
+++ b/W3ChampionsIdentificationService.Tests/UnitTests/Oidc/HandoffOriginValidatorTests.cs
@@ -1,0 +1,51 @@
+using NUnit.Framework;
+using W3ChampionsIdentificationService.Oidc;
+
+namespace W3ChampionsIdentificationService.Tests.UnitTests.Oidc;
+
+[TestFixture]
+public class HandoffOriginValidatorTests
+{
+    // The website login URL carries a path (/sso-continue); only its ORIGIN must match the
+    // request Origin header (which is a bare scheme+host+port).
+    private const string ProdLoginUrl = "https://www.w3champions.com/sso-continue";
+    private const string TestLoginUrl = "https://localhost:3000/sso-continue";
+
+    [TestCase("https://www.w3champions.com", ProdLoginUrl,
+        TestName = "Exact_prod_website_origin_is_allowed")]
+    [TestCase("https://localhost:3000", TestLoginUrl,
+        TestName = "Exact_test_website_origin_is_allowed")]
+    [TestCase("https://WWW.W3CHAMPIONS.COM", ProdLoginUrl,
+        TestName = "Origin_match_is_case_insensitive")]
+    public void AllowedOrigin_ReturnsTrue(string requestOrigin, string websiteLoginUrl)
+    {
+        Assert.IsTrue(HandoffOriginValidator.IsAllowedOrigin(requestOrigin, websiteLoginUrl));
+    }
+
+    [TestCase("https://evil.com", ProdLoginUrl,
+        TestName = "Different_origin_is_rejected")]
+    [TestCase("", ProdLoginUrl,
+        TestName = "Empty_origin_is_rejected")]
+    [TestCase(null, ProdLoginUrl,
+        TestName = "Null_origin_is_rejected")]
+    [TestCase("https://www.w3champions.com/evil", ProdLoginUrl,
+        TestName = "Origin_with_extra_path_is_rejected")]
+    [TestCase("http://www.w3champions.com", ProdLoginUrl,
+        TestName = "Http_vs_https_mismatch_is_rejected")]
+    [TestCase("https://www.w3champions.com:8443", ProdLoginUrl,
+        TestName = "Different_port_is_rejected")]
+    [TestCase("https://www.w3champions.com.evil.com", ProdLoginUrl,
+        TestName = "Lookalike_suffix_origin_is_rejected")]
+    [TestCase("not-an-origin", ProdLoginUrl,
+        TestName = "Unparseable_origin_is_rejected")]
+    public void DisallowedOrigin_ReturnsFalse(string requestOrigin, string websiteLoginUrl)
+    {
+        Assert.IsFalse(HandoffOriginValidator.IsAllowedOrigin(requestOrigin, websiteLoginUrl));
+    }
+
+    [Test]
+    public void EmptyWebsiteLoginUrl_RejectsEvenAMatchingLookingOrigin()
+    {
+        Assert.IsFalse(HandoffOriginValidator.IsAllowedOrigin("https://www.w3champions.com", ""));
+    }
+}

--- a/W3ChampionsIdentificationService.Tests/UnitTests/Oidc/HandoffOriginValidatorTests.cs
+++ b/W3ChampionsIdentificationService.Tests/UnitTests/Oidc/HandoffOriginValidatorTests.cs
@@ -7,36 +7,52 @@ namespace W3ChampionsIdentificationService.Tests.UnitTests.Oidc;
 public class HandoffOriginValidatorTests
 {
     // The website login URL carries a path (/sso-continue); only its ORIGIN must match the
-    // request Origin header (which is a bare scheme+host+port).
-    private const string ProdLoginUrl = "https://www.w3champions.com/sso-continue";
+    // request Origin header (which is a bare scheme+host+port). The w3champions site is reachable
+    // on both the apex and www, so both are accepted regardless of which is configured.
+    private const string ApexLoginUrl = "https://w3champions.com/sso-continue";
+    private const string WwwLoginUrl = "https://www.w3champions.com/sso-continue";
     private const string TestLoginUrl = "https://localhost:3000/sso-continue";
 
-    [TestCase("https://www.w3champions.com", ProdLoginUrl,
-        TestName = "Exact_prod_website_origin_is_allowed")]
+    [TestCase("https://w3champions.com", ApexLoginUrl,
+        TestName = "Apex_config_accepts_apex_origin")]
+    [TestCase("https://www.w3champions.com", ApexLoginUrl,
+        TestName = "Apex_config_accepts_www_sibling_origin")]
+    [TestCase("https://www.w3champions.com", WwwLoginUrl,
+        TestName = "Www_config_accepts_www_origin")]
+    [TestCase("https://w3champions.com", WwwLoginUrl,
+        TestName = "Www_config_accepts_apex_sibling_origin")]
+    [TestCase("https://W3CHAMPIONS.COM", ApexLoginUrl,
+        TestName = "Apex_match_is_case_insensitive")]
+    [TestCase("https://WWW.W3CHAMPIONS.COM", ApexLoginUrl,
+        TestName = "Www_sibling_match_is_case_insensitive")]
     [TestCase("https://localhost:3000", TestLoginUrl,
         TestName = "Exact_test_website_origin_is_allowed")]
-    [TestCase("https://WWW.W3CHAMPIONS.COM", ProdLoginUrl,
-        TestName = "Origin_match_is_case_insensitive")]
+    [TestCase("https://www.localhost:3000", TestLoginUrl,
+        TestName = "Test_config_accepts_www_sibling_with_port")]
     public void AllowedOrigin_ReturnsTrue(string requestOrigin, string websiteLoginUrl)
     {
         Assert.IsTrue(HandoffOriginValidator.IsAllowedOrigin(requestOrigin, websiteLoginUrl));
     }
 
-    [TestCase("https://evil.com", ProdLoginUrl,
+    [TestCase("https://evil.com", ApexLoginUrl,
         TestName = "Different_origin_is_rejected")]
-    [TestCase("", ProdLoginUrl,
+    [TestCase("https://www.evil.com", ApexLoginUrl,
+        TestName = "Www_of_a_different_origin_is_rejected")]
+    [TestCase("", ApexLoginUrl,
         TestName = "Empty_origin_is_rejected")]
-    [TestCase(null, ProdLoginUrl,
+    [TestCase(null, ApexLoginUrl,
         TestName = "Null_origin_is_rejected")]
-    [TestCase("https://www.w3champions.com/evil", ProdLoginUrl,
+    [TestCase("https://w3champions.com/evil", ApexLoginUrl,
         TestName = "Origin_with_extra_path_is_rejected")]
-    [TestCase("http://www.w3champions.com", ProdLoginUrl,
+    [TestCase("http://w3champions.com", ApexLoginUrl,
         TestName = "Http_vs_https_mismatch_is_rejected")]
-    [TestCase("https://www.w3champions.com:8443", ProdLoginUrl,
+    [TestCase("https://w3champions.com:8443", ApexLoginUrl,
         TestName = "Different_port_is_rejected")]
-    [TestCase("https://www.w3champions.com.evil.com", ProdLoginUrl,
+    [TestCase("https://w3champions.com.evil.com", ApexLoginUrl,
         TestName = "Lookalike_suffix_origin_is_rejected")]
-    [TestCase("not-an-origin", ProdLoginUrl,
+    [TestCase("https://www.w3champions.com.evil.com", ApexLoginUrl,
+        TestName = "Www_lookalike_suffix_origin_is_rejected")]
+    [TestCase("not-an-origin", ApexLoginUrl,
         TestName = "Unparseable_origin_is_rejected")]
     public void DisallowedOrigin_ReturnsFalse(string requestOrigin, string websiteLoginUrl)
     {
@@ -46,6 +62,6 @@ public class HandoffOriginValidatorTests
     [Test]
     public void EmptyWebsiteLoginUrl_RejectsEvenAMatchingLookingOrigin()
     {
-        Assert.IsFalse(HandoffOriginValidator.IsAllowedOrigin("https://www.w3champions.com", ""));
+        Assert.IsFalse(HandoffOriginValidator.IsAllowedOrigin("https://w3champions.com", ""));
     }
 }

--- a/W3ChampionsIdentificationService.Tests/UnitTests/Oidc/HandoffReturnUrlValidatorTests.cs
+++ b/W3ChampionsIdentificationService.Tests/UnitTests/Oidc/HandoffReturnUrlValidatorTests.cs
@@ -12,6 +12,8 @@ public class HandoffReturnUrlValidatorTests
         true, TestName = "Test_origin_with_path_is_allowed")]
     [TestCase("https://identification-service.w3champions.com",
         true, TestName = "Prod_origin_only_is_allowed")]
+    [TestCase("https://identification-service.w3champions.com:443/connect/authorize",
+        true, TestName = "Explicit_default_port_443_normalizes_and_is_allowed")]
     public void AllowedOrigins_ReturnTrue(string url, bool expected)
     {
         Assert.AreEqual(expected, HandoffReturnUrlValidator.IsAllowed(url));
@@ -25,6 +27,10 @@ public class HandoffReturnUrlValidatorTests
         TestName = "Open_redirect_attempt_is_rejected")]
     [TestCase("https://identification-service.w3champions.com.evil.com/connect/authorize",
         TestName = "Subdomain_spoof_is_rejected")]
+    [TestCase("https://identification-service.w3champions.com@evil.com/connect/authorize",
+        TestName = "Userinfo_injection_is_rejected")]
+    [TestCase("https://identification-service.w3champions.com:8443/connect/authorize",
+        TestName = "Non_default_port_is_rejected")]
     [TestCase("",   TestName = "Empty_string_is_rejected")]
     [TestCase(null, TestName = "Null_is_rejected")]
     [TestCase("not-a-url", TestName = "Non_url_is_rejected")]

--- a/W3ChampionsIdentificationService.Tests/UnitTests/Oidc/HandoffReturnUrlValidatorTests.cs
+++ b/W3ChampionsIdentificationService.Tests/UnitTests/Oidc/HandoffReturnUrlValidatorTests.cs
@@ -31,7 +31,7 @@ public class HandoffReturnUrlValidatorTests
         TestName = "Userinfo_injection_is_rejected")]
     [TestCase("https://identification-service.w3champions.com:8443/connect/authorize",
         TestName = "Non_default_port_is_rejected")]
-    [TestCase("",   TestName = "Empty_string_is_rejected")]
+    [TestCase("", TestName = "Empty_string_is_rejected")]
     [TestCase(null, TestName = "Null_is_rejected")]
     [TestCase("not-a-url", TestName = "Non_url_is_rejected")]
     [TestCase("javascript:alert(1)", TestName = "Javascript_scheme_is_rejected")]

--- a/W3ChampionsIdentificationService.Tests/UnitTests/Oidc/HandoffReturnUrlValidatorTests.cs
+++ b/W3ChampionsIdentificationService.Tests/UnitTests/Oidc/HandoffReturnUrlValidatorTests.cs
@@ -1,0 +1,36 @@
+using NUnit.Framework;
+using W3ChampionsIdentificationService.Oidc;
+
+namespace W3ChampionsIdentificationService.Tests.UnitTests.Oidc;
+
+[TestFixture]
+public class HandoffReturnUrlValidatorTests
+{
+    [TestCase("https://identification-service.w3champions.com/connect/authorize?code=abc",
+        true, TestName = "Prod_origin_with_path_is_allowed")]
+    [TestCase("https://identification-service.test.w3champions.com/connect/authorize?state=x",
+        true, TestName = "Test_origin_with_path_is_allowed")]
+    [TestCase("https://identification-service.w3champions.com",
+        true, TestName = "Prod_origin_only_is_allowed")]
+    public void AllowedOrigins_ReturnTrue(string url, bool expected)
+    {
+        Assert.AreEqual(expected, HandoffReturnUrlValidator.IsAllowed(url));
+    }
+
+    [TestCase("http://identification-service.w3champions.com/connect/authorize",
+        TestName = "HTTP_is_rejected")]
+    [TestCase("https://w3champions.com/connect/authorize",
+        TestName = "Apex_domain_is_rejected")]
+    [TestCase("https://evil.com/redirect?to=identification-service.w3champions.com",
+        TestName = "Open_redirect_attempt_is_rejected")]
+    [TestCase("https://identification-service.w3champions.com.evil.com/connect/authorize",
+        TestName = "Subdomain_spoof_is_rejected")]
+    [TestCase("",   TestName = "Empty_string_is_rejected")]
+    [TestCase(null, TestName = "Null_is_rejected")]
+    [TestCase("not-a-url", TestName = "Non_url_is_rejected")]
+    [TestCase("javascript:alert(1)", TestName = "Javascript_scheme_is_rejected")]
+    public void DisallowedValues_ReturnFalse(string url)
+    {
+        Assert.IsFalse(HandoffReturnUrlValidator.IsAllowed(url));
+    }
+}

--- a/W3ChampionsIdentificationService.Tests/UnitTests/Oidc/OidcClaimMapperTests.cs
+++ b/W3ChampionsIdentificationService.Tests/UnitTests/Oidc/OidcClaimMapperTests.cs
@@ -36,4 +36,34 @@ public class OidcClaimMapperTests
         var email = OidcClaimMapper.BattleTagToSyntheticEmail("Test#1");
         StringAssert.EndsWith("@w3champions.invalid", email);
     }
+
+    [TestCase("Ümläut#12", TestName = "Accented_Latin_falls_back_to_ascii_hash")]
+    [TestCase("玩家#7", TestName = "CJK_falls_back_to_ascii_hash")]
+    [TestCase("Кирилл#3", TestName = "Cyrillic_falls_back_to_ascii_hash")]
+    public void NonAsciiBattleTag_ProducesAsciiHashEmail(string battleTag)
+    {
+        var email = OidcClaimMapper.BattleTagToSyntheticEmail(battleTag);
+
+        StringAssert.IsMatch(@"^[a-z0-9._-]+@w3champions\.invalid$", email);
+        StringAssert.StartsWith("u-", email);
+        Assert.IsFalse(email.Contains('#'));
+    }
+
+    [Test]
+    public void NonAsciiBattleTags_AreInjective_DistinctInputsProduceDistinctEmails()
+    {
+        var first = OidcClaimMapper.BattleTagToSyntheticEmail("Ümläut#12");
+        var second = OidcClaimMapper.BattleTagToSyntheticEmail("玩家#7");
+
+        Assert.AreNotEqual(first, second);
+    }
+
+    [Test]
+    public void NonAsciiBattleTag_IsDeterministic_SameInputProducesSameEmail()
+    {
+        var first = OidcClaimMapper.BattleTagToSyntheticEmail("Кирилл#3");
+        var second = OidcClaimMapper.BattleTagToSyntheticEmail("Кирилл#3");
+
+        Assert.AreEqual(first, second);
+    }
 }

--- a/W3ChampionsIdentificationService.Tests/UnitTests/Oidc/OidcClaimMapperTests.cs
+++ b/W3ChampionsIdentificationService.Tests/UnitTests/Oidc/OidcClaimMapperTests.cs
@@ -1,0 +1,39 @@
+using NUnit.Framework;
+using W3ChampionsIdentificationService.Oidc;
+
+namespace W3ChampionsIdentificationService.Tests.UnitTests.Oidc;
+
+[TestFixture]
+public class OidcClaimMapperTests
+{
+    [TestCase("Modmoto#2809", "modmoto-2809@w3champions.invalid")]
+    [TestCase("Player#12345", "player-12345@w3champions.invalid")]
+    [TestCase("UPPER#999",   "upper-999@w3champions.invalid")]
+    public void BattleTagToSyntheticEmail_HashReplacedWithDash_LowercaseLocalPart(
+        string battleTag, string expectedEmail)
+    {
+        var result = OidcClaimMapper.BattleTagToSyntheticEmail(battleTag);
+        Assert.AreEqual(expectedEmail, result);
+    }
+
+    [Test]
+    public void BattleTagToSyntheticEmail_NullInput_ThrowsArgumentException()
+    {
+        Assert.Throws<System.ArgumentException>(() =>
+            OidcClaimMapper.BattleTagToSyntheticEmail(null));
+    }
+
+    [Test]
+    public void SyntheticEmail_DoesNotContainHash()
+    {
+        var email = OidcClaimMapper.BattleTagToSyntheticEmail("Test#1");
+        Assert.IsFalse(email.Contains('#'));
+    }
+
+    [Test]
+    public void SyntheticEmail_DomainIsCorrect()
+    {
+        var email = OidcClaimMapper.BattleTagToSyntheticEmail("Test#1");
+        StringAssert.EndsWith("@w3champions.invalid", email);
+    }
+}

--- a/W3ChampionsIdentificationService.Tests/UnitTests/Oidc/OidcClaimMapperTests.cs
+++ b/W3ChampionsIdentificationService.Tests/UnitTests/Oidc/OidcClaimMapperTests.cs
@@ -8,7 +8,7 @@ public class OidcClaimMapperTests
 {
     [TestCase("Modmoto#2809", "modmoto-2809@w3champions.invalid")]
     [TestCase("Player#12345", "player-12345@w3champions.invalid")]
-    [TestCase("UPPER#999",   "upper-999@w3champions.invalid")]
+    [TestCase("UPPER#999", "upper-999@w3champions.invalid")]
     public void BattleTagToSyntheticEmail_HashReplacedWithDash_LowercaseLocalPart(
         string battleTag, string expectedEmail)
     {

--- a/W3ChampionsIdentificationService.Tests/UnitTests/Oidc/OidcClientCliArgsTests.cs
+++ b/W3ChampionsIdentificationService.Tests/UnitTests/Oidc/OidcClientCliArgsTests.cs
@@ -1,0 +1,91 @@
+using System;
+using NUnit.Framework;
+using W3ChampionsIdentificationService.Oidc.Cli;
+
+namespace W3ChampionsIdentificationService.Tests.UnitTests.Oidc;
+
+[TestFixture]
+public class OidcClientCliArgsTests
+{
+    [Test]
+    public void ParseRegisterArgs_ValidArgs_ReturnsExpectedRecord()
+    {
+        var result = OidcClientCli.ParseRegisterArgs(
+        [
+            "register-client",
+            "--client-id", "quackback",
+            "--redirect-uri", "https://feedback.w3champions.com/callback",
+            "--scopes", "openid,email"
+        ]);
+
+        Assert.AreEqual("quackback", result.ClientId);
+        Assert.AreEqual("https://feedback.w3champions.com/callback", result.RedirectUri);
+        Assert.AreEqual(new[] { "openid", "email" }, result.Scopes);
+        Assert.IsFalse(result.Update);
+    }
+
+    [Test]
+    public void ParseRegisterArgs_NoScopes_DefaultsToOpenidProfileEmail()
+    {
+        var result = OidcClientCli.ParseRegisterArgs(
+        [
+            "register-client",
+            "--client-id", "quackback",
+            "--redirect-uri", "https://feedback.w3champions.com/callback"
+        ]);
+
+        Assert.AreEqual(new[] { "openid", "profile", "email" }, result.Scopes);
+    }
+
+    [Test]
+    public void ParseRegisterArgs_UpdateFlag_SetsUpdateTrue()
+    {
+        var result = OidcClientCli.ParseRegisterArgs(
+        [
+            "register-client",
+            "--client-id", "quackback",
+            "--redirect-uri", "https://feedback.w3champions.com/callback",
+            "--update"
+        ]);
+
+        Assert.IsTrue(result.Update);
+    }
+
+    [Test]
+    public void ParseRegisterArgs_TrailingValuelessFlag_ThrowsArgumentException()
+    {
+        // --client-id is the last token: must throw cleanly, not IndexOutOfRangeException.
+        Assert.Throws<ArgumentException>(() =>
+            OidcClientCli.ParseRegisterArgs(["register-client", "--client-id"]));
+    }
+
+    [Test]
+    public void ParseRegisterArgs_MissingClientId_ThrowsArgumentException()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            OidcClientCli.ParseRegisterArgs(
+            [
+                "register-client",
+                "--redirect-uri", "https://feedback.w3champions.com/callback"
+            ]));
+    }
+
+    [Test]
+    public void ParseRegisterArgs_MissingRedirectUri_ThrowsArgumentException()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            OidcClientCli.ParseRegisterArgs(["register-client", "--client-id", "quackback"]));
+    }
+
+    [Test]
+    public void ParseRegisterArgs_HttpRedirectUri_ThrowsArgumentException()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            OidcClientCli.ParseRegisterArgs(
+            [
+                "register-client",
+                "--client-id", "quackback",
+                "--redirect-uri", "http://feedback.w3champions.com/callback"
+            ]));
+    }
+}

--- a/W3ChampionsIdentificationService.Tests/UnitTests/Oidc/OidcClientSecretTests.cs
+++ b/W3ChampionsIdentificationService.Tests/UnitTests/Oidc/OidcClientSecretTests.cs
@@ -1,0 +1,31 @@
+using NUnit.Framework;
+using W3ChampionsIdentificationService.Oidc.Cli;
+
+namespace W3ChampionsIdentificationService.Tests.UnitTests.Oidc;
+
+[TestFixture]
+public class OidcClientSecretTests
+{
+    [Test]
+    public void GeneratedSecret_Is32BytesBase64_Length44()
+    {
+        Assert.AreEqual(44, OidcClientCli.GenerateSecret().Length);
+    }
+
+    [Test]
+    public void TwoGeneratedSecrets_AreNotEqual()
+    {
+        Assert.AreNotEqual(OidcClientCli.GenerateSecret(), OidcClientCli.GenerateSecret());
+    }
+
+    [TestCase("https://feedback.w3champions.com/api/auth/oauth2/callback/custom-oidc", true)]
+    [TestCase("https://example.com/callback", true)]
+    [TestCase("http://example.com/callback",  false, TestName = "HTTP_rejected")]
+    [TestCase("",                              false, TestName = "Empty_rejected")]
+    [TestCase(null,                            false, TestName = "Null_rejected")]
+    [TestCase("not-a-url",                     false, TestName = "Relative_rejected")]
+    public void RedirectUri_HttpsGuard(string uri, bool shouldPass)
+    {
+        Assert.AreEqual(shouldPass, OidcClientCli.IsValidHttpsRedirectUri(uri));
+    }
+}

--- a/W3ChampionsIdentificationService.Tests/UnitTests/Oidc/OidcClientSecretTests.cs
+++ b/W3ChampionsIdentificationService.Tests/UnitTests/Oidc/OidcClientSecretTests.cs
@@ -20,10 +20,10 @@ public class OidcClientSecretTests
 
     [TestCase("https://feedback.w3champions.com/api/auth/oauth2/callback/custom-oidc", true)]
     [TestCase("https://example.com/callback", true)]
-    [TestCase("http://example.com/callback",  false, TestName = "HTTP_rejected")]
-    [TestCase("",                              false, TestName = "Empty_rejected")]
-    [TestCase(null,                            false, TestName = "Null_rejected")]
-    [TestCase("not-a-url",                     false, TestName = "Relative_rejected")]
+    [TestCase("http://example.com/callback", false, TestName = "HTTP_rejected")]
+    [TestCase("", false, TestName = "Empty_rejected")]
+    [TestCase(null, false, TestName = "Null_rejected")]
+    [TestCase("not-a-url", false, TestName = "Relative_rejected")]
     public void RedirectUri_HttpsGuard(string uri, bool shouldPass)
     {
         Assert.AreEqual(shouldPass, OidcClientCli.IsValidHttpsRedirectUri(uri));

--- a/W3ChampionsIdentificationService/Config/AppConfig.cs
+++ b/W3ChampionsIdentificationService/Config/AppConfig.cs
@@ -18,6 +18,9 @@ public class AppConfig : IAppConfig
     public string OidcSigningKeyPem
         => Regex.Unescape(Environment.GetEnvironmentVariable("OIDC_SIGNING_KEY_PEM") ?? "");
 
+    public string OidcEncryptionKeyPem
+        => Regex.Unescape(Environment.GetEnvironmentVariable("OIDC_ENCRYPTION_KEY_PEM") ?? "");
+
     public string WebsiteLoginUrl
         => Environment.GetEnvironmentVariable("WEBSITE_LOGIN_URL") ?? "https://localhost:3000/sso-continue";
 

--- a/W3ChampionsIdentificationService/Config/AppConfig.cs
+++ b/W3ChampionsIdentificationService/Config/AppConfig.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Text.RegularExpressions;
 
 namespace W3ChampionsIdentificationService.Config;
 
@@ -13,4 +14,13 @@ public class AppConfig : IAppConfig
     {
         get => "W3Champions-Identification-Service";
     }
+
+    public string OidcSigningKeyPem
+        => Regex.Unescape(Environment.GetEnvironmentVariable("OIDC_SIGNING_KEY_PEM") ?? "");
+
+    public string WebsiteLoginUrl
+        => Environment.GetEnvironmentVariable("WEBSITE_LOGIN_URL") ?? "https://localhost:3000/sso-continue";
+
+    public string OidcIssuer
+        => Environment.GetEnvironmentVariable("OIDC_ISSUER") ?? "https://localhost:5050";
 }

--- a/W3ChampionsIdentificationService/Config/IAppConfig.cs
+++ b/W3ChampionsIdentificationService/Config/IAppConfig.cs
@@ -5,6 +5,7 @@ public interface IAppConfig
     string MongoConnectionString { get; }
     string DatabaseName { get; }
     string OidcSigningKeyPem { get; }
+    string OidcEncryptionKeyPem { get; }
     string WebsiteLoginUrl { get; }
     string OidcIssuer { get; }
 }

--- a/W3ChampionsIdentificationService/Config/IAppConfig.cs
+++ b/W3ChampionsIdentificationService/Config/IAppConfig.cs
@@ -4,4 +4,7 @@ public interface IAppConfig
 {
     string MongoConnectionString { get; }
     string DatabaseName { get; }
+    string OidcSigningKeyPem { get; }
+    string WebsiteLoginUrl { get; }
+    string OidcIssuer { get; }
 }

--- a/W3ChampionsIdentificationService/DataProtection/MongoXmlRepository.cs
+++ b/W3ChampionsIdentificationService/DataProtection/MongoXmlRepository.cs
@@ -1,0 +1,60 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Xml.Linq;
+using Microsoft.AspNetCore.DataProtection.Repositories;
+using MongoDB.Bson;
+using MongoDB.Driver;
+
+namespace W3ChampionsIdentificationService.DataProtection;
+
+/// <summary>
+/// An <see cref="IXmlRepository"/> that persists the ASP.NET Core DataProtection key ring
+/// to a MongoDB collection so it survives restarts and is shared across replicas.
+///
+/// Why this exists: the IdP session cookie (<c>__Host-w3c-idp-session</c>) is encrypted with
+/// DataProtection. The default key ring is EPHEMERAL and per-instance, so a cookie set by one
+/// replica (or before a restart) cannot be decrypted by another — the SSO handoff would set the
+/// cookie on one instance and the redirected /connect/authorize could land on another that fails
+/// to authenticate it, looping the user back through login. Persisting the key ring to the
+/// already-present MongoDB makes it durable and shared with no new infrastructure.
+///
+/// This is distinct from OIDC_ENCRYPTION_KEY_PEM, which protects OpenIddict authorization codes;
+/// this protects the ASP.NET cookie key ring.
+/// </summary>
+public sealed class MongoXmlRepository(IMongoCollection<BsonDocument> collection) : IXmlRepository
+{
+    // DataProtection stores each key as a top-level <key> XML element. We persist one Mongo
+    // document per element: { _id: <friendlyName or generated>, xml: "<key>...</key>" }.
+    private const string XmlField = "xml";
+
+    private readonly IMongoCollection<BsonDocument> _collection = collection;
+
+    public IReadOnlyCollection<XElement> GetAllElements() =>
+        _collection
+            .Find(FilterDefinition<BsonDocument>.Empty)
+            .ToList()
+            .Where(doc => doc.Contains(XmlField) && doc[XmlField].IsString)
+            .Select(doc => XElement.Parse(doc[XmlField].AsString))
+            .ToList();
+
+    public void StoreElement(XElement element, string friendlyName)
+    {
+        // DataProtection supplies the key id as friendlyName; use it as the document _id so a
+        // re-store of the same key upserts in place rather than duplicating. When absent, fall
+        // back to a generated ObjectId so the element is still persisted exactly once.
+        var id = string.IsNullOrEmpty(friendlyName)
+            ? ObjectId.GenerateNewId().ToString()
+            : friendlyName;
+
+        var document = new BsonDocument
+        {
+            ["_id"] = id,
+            [XmlField] = element.ToString(SaveOptions.DisableFormatting),
+        };
+
+        _collection.ReplaceOne(
+            Builders<BsonDocument>.Filter.Eq("_id", id),
+            document,
+            new ReplaceOptions { IsUpsert = true });
+    }
+}

--- a/W3ChampionsIdentificationService/DatabaseModels/IVersionable.cs
+++ b/W3ChampionsIdentificationService/DatabaseModels/IVersionable.cs
@@ -4,5 +4,14 @@ namespace W3ChampionsIdentificationService.DatabaseModels;
 
 public interface IVersionable
 {
+    // MIGRATION NOTE (MongoDB.Driver 3.x): the default BSON serialization of
+    // DateTimeOffset changed from a 2-element array [ticks, offset] in driver 2.x to a
+    // document { DateTime, Offset } in driver 3.x. Any concrete class implementing this
+    // interface that persists existing 2.x-format documents MUST annotate its LastUpdated
+    // property with [BsonRepresentation(BsonType.Array)] to stay byte-compatible with
+    // already-stored data. The attribute cannot live here: the driver's class map reflects
+    // over the concrete type's members and does NOT honor BSON attributes declared on an
+    // interface, so an attribute on this interface property would silently be a no-op.
+    // (No concrete type implements IVersionable today — this is currently dead code.)
     public DateTimeOffset LastUpdated { get; set; }
 }

--- a/W3ChampionsIdentificationService/DatabaseModels/IVersionable.cs
+++ b/W3ChampionsIdentificationService/DatabaseModels/IVersionable.cs
@@ -6,10 +6,11 @@ public interface IVersionable
 {
     // MIGRATION NOTE (MongoDB.Driver 3.x): the default BSON serialization of
     // DateTimeOffset changed from a 2-element array [ticks, offset] in driver 2.x to a
-    // document { DateTime, Offset } in driver 3.x. Any concrete class implementing this
-    // interface that persists existing 2.x-format documents MUST annotate its LastUpdated
-    // property with [BsonRepresentation(BsonType.Array)] to stay byte-compatible with
-    // already-stored data. The attribute cannot live here: the driver's class map reflects
+    // document { DateTime, Offset } in driver 3.x. A concrete class implementing this
+    // interface must, if it persists pre-existing 2.x-format documents, annotate its
+    // LastUpdated property with [BsonRepresentation(BsonType.Array)] to stay byte-compatible
+    // with already-stored data. (A brand-new collection that never held 2.x data needs no
+    // such attribute — the 3.x default is fine.) The attribute cannot live here: the driver's class map reflects
     // over the concrete type's members and does NOT honor BSON attributes declared on an
     // interface, so an attribute on this interface property would silently be a no-op.
     // (No concrete type implements IVersionable today — this is currently dead code.)

--- a/W3ChampionsIdentificationService/Oidc/Cli/OidcClientCli.cs
+++ b/W3ChampionsIdentificationService/Oidc/Cli/OidcClientCli.cs
@@ -4,6 +4,7 @@ using System.Security.Cryptography;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using MongoDB.Driver;
 using OpenIddict.Abstractions;
 using W3ChampionsIdentificationService.Config;
@@ -17,20 +18,30 @@ public static class OidcClientCli
     {
         var subcommand = args[0];
         using var host = BuildCliHost(args);
-        await host.StartAsync();
-
-        var manager = host.Services.GetRequiredService<IOpenIddictApplicationManager>();
-
-        int exitCode = subcommand switch
+        try
         {
-            "register-client" => await RegisterClient(args, manager),
-            "list-clients"    => await ListClients(manager),
-            "delete-client"   => await DeleteClient(args, manager),
-            _ => Usage()
-        };
-
-        await host.StopAsync();
-        return exitCode;
+            await host.StartAsync();
+            var manager = host.Services.GetRequiredService<IOpenIddictApplicationManager>();
+            return subcommand switch
+            {
+                "register-client" => await RegisterClient(args, manager),
+                "list-clients"    => await ListClients(manager),
+                "delete-client"   => await DeleteClient(args, manager),
+                _ => Usage()
+            };
+        }
+        catch (Exception ex)
+        {
+            // Surface transient/operational failures (Mongo unreachable, duplicate-key,
+            // descriptor validation, missing-arg) as a clean stderr line + nonzero exit
+            // instead of an unhandled stack dump.
+            Console.Error.WriteLine($"ERROR: {ex.Message}");
+            return 1;
+        }
+        finally
+        {
+            await host.StopAsync();
+        }
     }
 
     /// <summary>Generates a 256-bit random client secret as base64 (44 chars). Public for testability.</summary>
@@ -46,7 +57,16 @@ public static class OidcClientCli
         Uri.TryCreate(uri, UriKind.Absolute, out var parsed) &&
         string.Equals(parsed.Scheme, "https", StringComparison.OrdinalIgnoreCase);
 
-    private static async Task<int> RegisterClient(string[] args, IOpenIddictApplicationManager manager)
+    /// <summary>Parsed + validated register-client arguments. Public for testability.</summary>
+    public sealed record RegisterArgs(string ClientId, string RedirectUri, string[] Scopes, bool Update);
+
+    /// <summary>
+    /// Parses and validates the register-client argument vector. Throws <see cref="ArgumentException"/>
+    /// on a missing value (e.g. a trailing valueless flag) or a missing/invalid required argument;
+    /// the top-level handler in <see cref="RunAsync"/> turns that into a clean stderr line + exit 1.
+    /// Public for testability.
+    /// </summary>
+    public static RegisterArgs ParseRegisterArgs(string[] args)
     {
         string clientId = null, redirectUri = null;
         string[] scopes = ["openid", "profile", "email"];
@@ -56,33 +76,41 @@ public static class OidcClientCli
         {
             switch (args[i])
             {
-                case "--client-id":    clientId    = args[++i]; break;
-                case "--redirect-uri": redirectUri = args[++i]; break;
-                case "--scopes":       scopes      = args[++i].Split(','); break;
+                case "--client-id":    clientId    = NextValue(args, ref i); break;
+                case "--redirect-uri": redirectUri = NextValue(args, ref i); break;
+                case "--scopes":       scopes      = NextValue(args, ref i).Split(','); break;
                 case "--update":       update      = true; break;
             }
         }
 
-        if (string.IsNullOrEmpty(clientId))
-        {
-            Console.Error.WriteLine("ERROR: --client-id is required");
-            return 1;
-        }
-        if (string.IsNullOrEmpty(redirectUri))
-        {
-            Console.Error.WriteLine("ERROR: --redirect-uri is required");
-            return 1;
-        }
+        if (string.IsNullOrEmpty(clientId))    throw new ArgumentException("--client-id is required");
+        if (string.IsNullOrEmpty(redirectUri)) throw new ArgumentException("--redirect-uri is required");
         if (!IsValidHttpsRedirectUri(redirectUri))
-        {
-            Console.Error.WriteLine($"ERROR: redirect-uri must be an absolute HTTPS URL, got: {redirectUri}");
-            return 1;
-        }
+            throw new ArgumentException($"redirect-uri must be an absolute HTTPS URL, got: {redirectUri}");
 
-        var existing = await manager.FindByClientIdAsync(clientId);
-        if (existing != null && !update)
+        return new RegisterArgs(clientId, redirectUri, scopes, update);
+    }
+
+    /// <summary>
+    /// Returns the value following the flag at <paramref name="i"/>, advancing the index.
+    /// Throws <see cref="ArgumentException"/> when the flag is the last token (no value) so the
+    /// CLI fails cleanly via the top-level handler instead of an IndexOutOfRangeException dump.
+    /// </summary>
+    private static string NextValue(string[] args, ref int i)
+    {
+        if (i + 1 >= args.Length)
+            throw new ArgumentException($"{args[i]} requires a value");
+        return args[++i];
+    }
+
+    private static async Task<int> RegisterClient(string[] args, IOpenIddictApplicationManager manager)
+    {
+        var parsed = ParseRegisterArgs(args);
+
+        var existing = await manager.FindByClientIdAsync(parsed.ClientId);
+        if (existing != null && !parsed.Update)
         {
-            Console.Error.WriteLine($"ERROR: Client '{clientId}' already exists. Re-run with --update to overwrite.");
+            Console.Error.WriteLine($"ERROR: Client '{parsed.ClientId}' already exists. Re-run with --update to overwrite.");
             return 1;
         }
 
@@ -90,9 +118,11 @@ public static class OidcClientCli
 
         var descriptor = new OpenIddictApplicationDescriptor
         {
-            ClientId     = clientId,
+            ClientId     = parsed.ClientId,
             ClientSecret = rawSecret,       // OpenIddict hashes this via PBKDF2 internally.
             ClientType   = ClientTypes.Confidential,
+            // Implicit consent: Quackback is a first-party trusted client, so no consent
+            // screen is shown (the IdP has no consent UI to render one).
             ConsentType  = ConsentTypes.Implicit,
             Permissions  =
             {
@@ -105,21 +135,26 @@ public static class OidcClientCli
                 Permissions.Scopes.Profile,
                 Permissions.Scopes.Email,
             },
-            RedirectUris = { new Uri(redirectUri) },
+            RedirectUris = { new Uri(parsed.RedirectUri) },
             Requirements = { Requirements.Features.ProofKeyForCodeExchange },
         };
 
-        if (!scopes.Contains("profile", StringComparer.OrdinalIgnoreCase))
+        if (!parsed.Scopes.Contains("profile", StringComparer.OrdinalIgnoreCase))
             descriptor.Permissions.Remove(Permissions.Scopes.Profile);
-        if (!scopes.Contains("email",   StringComparer.OrdinalIgnoreCase))
+        if (!parsed.Scopes.Contains("email",   StringComparer.OrdinalIgnoreCase))
             descriptor.Permissions.Remove(Permissions.Scopes.Email);
 
-        if (existing != null && update)
-            await manager.DeleteAsync(existing);
+        if (existing != null && parsed.Update)
+        {
+            await manager.UpdateAsync(existing, descriptor);
+            Console.Error.WriteLine("NOTE: --update rotated the client secret; update the downstream client config.");
+        }
+        else
+        {
+            await manager.CreateAsync(descriptor);
+        }
 
-        await manager.CreateAsync(descriptor);
-
-        Console.WriteLine($"Client '{clientId}' registered successfully.");
+        Console.WriteLine($"Client '{parsed.ClientId}' registered successfully.");
         Console.WriteLine($"CLIENT_SECRET (copy now — will not be shown again): {rawSecret}");
         return 0;
     }
@@ -141,7 +176,7 @@ public static class OidcClientCli
     {
         string clientId = null;
         for (int i = 1; i < args.Length; i++)
-            if (args[i] == "--client-id") clientId = args[++i];
+            if (args[i] == "--client-id") clientId = NextValue(args, ref i);
 
         if (string.IsNullOrEmpty(clientId))
         {
@@ -163,7 +198,7 @@ public static class OidcClientCli
 
     private static int Usage()
     {
-        Console.Error.WriteLine("Usage: register-client --client-id <id> --redirect-uri <uri> [--scopes openid,profile,email] [--update]");
+        Console.Error.WriteLine("Usage: register-client --client-id <id> --redirect-uri <uri> [--scopes openid,profile,email] [--update rotates the secret]");
         Console.Error.WriteLine("       list-clients");
         Console.Error.WriteLine("       delete-client --client-id <id>");
         return 1;
@@ -171,11 +206,18 @@ public static class OidcClientCli
 
     private static IHost BuildCliHost(string[] args) =>
         Host.CreateDefaultBuilder()
+            .ConfigureLogging(logging =>
+            {
+                // Quiet the default console logging provider + host-lifetime Information logs:
+                // they write to stdout — the same stream as the once-only CLIENT_SECRET line —
+                // so an operator could mis-copy. Errors are surfaced via Console.Error in RunAsync.
+                logging.ClearProviders();
+                logging.SetMinimumLevel(LogLevel.Warning);
+            })
             .ConfigureServices((_, services) =>
             {
                 var appConfig = new AppConfig();
                 services.AddSingleton<IAppConfig>(appConfig);
-                services.AddSingleton(_ => new MongoClient(appConfig.MongoConnectionString));
                 services.AddOpenIddict()
                     .AddCore(core =>
                     {

--- a/W3ChampionsIdentificationService/Oidc/Cli/OidcClientCli.cs
+++ b/W3ChampionsIdentificationService/Oidc/Cli/OidcClientCli.cs
@@ -1,0 +1,189 @@
+using System;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using MongoDB.Driver;
+using OpenIddict.Abstractions;
+using W3ChampionsIdentificationService.Config;
+using static OpenIddict.Abstractions.OpenIddictConstants;
+
+namespace W3ChampionsIdentificationService.Oidc.Cli;
+
+public static class OidcClientCli
+{
+    public static async Task<int> RunAsync(string[] args)
+    {
+        var subcommand = args[0];
+        using var host = BuildCliHost(args);
+        await host.StartAsync();
+
+        var manager = host.Services.GetRequiredService<IOpenIddictApplicationManager>();
+
+        int exitCode = subcommand switch
+        {
+            "register-client" => await RegisterClient(args, manager),
+            "list-clients"    => await ListClients(manager),
+            "delete-client"   => await DeleteClient(args, manager),
+            _ => Usage()
+        };
+
+        await host.StopAsync();
+        return exitCode;
+    }
+
+    /// <summary>Generates a 256-bit random client secret as base64 (44 chars). Public for testability.</summary>
+    public static string GenerateSecret()
+    {
+        var bytes = new byte[32];
+        RandomNumberGenerator.Fill(bytes);
+        return Convert.ToBase64String(bytes);
+    }
+
+    /// <summary>True if the redirect URI is an absolute HTTPS URL. Public for testability.</summary>
+    public static bool IsValidHttpsRedirectUri(string uri) =>
+        Uri.TryCreate(uri, UriKind.Absolute, out var parsed) &&
+        string.Equals(parsed.Scheme, "https", StringComparison.OrdinalIgnoreCase);
+
+    private static async Task<int> RegisterClient(string[] args, IOpenIddictApplicationManager manager)
+    {
+        string clientId = null, redirectUri = null;
+        string[] scopes = ["openid", "profile", "email"];
+        bool update = false;
+
+        for (int i = 1; i < args.Length; i++)
+        {
+            switch (args[i])
+            {
+                case "--client-id":    clientId    = args[++i]; break;
+                case "--redirect-uri": redirectUri = args[++i]; break;
+                case "--scopes":       scopes      = args[++i].Split(','); break;
+                case "--update":       update      = true; break;
+            }
+        }
+
+        if (string.IsNullOrEmpty(clientId))
+        {
+            Console.Error.WriteLine("ERROR: --client-id is required");
+            return 1;
+        }
+        if (string.IsNullOrEmpty(redirectUri))
+        {
+            Console.Error.WriteLine("ERROR: --redirect-uri is required");
+            return 1;
+        }
+        if (!IsValidHttpsRedirectUri(redirectUri))
+        {
+            Console.Error.WriteLine($"ERROR: redirect-uri must be an absolute HTTPS URL, got: {redirectUri}");
+            return 1;
+        }
+
+        var existing = await manager.FindByClientIdAsync(clientId);
+        if (existing != null && !update)
+        {
+            Console.Error.WriteLine($"ERROR: Client '{clientId}' already exists. Re-run with --update to overwrite.");
+            return 1;
+        }
+
+        var rawSecret = GenerateSecret();
+
+        var descriptor = new OpenIddictApplicationDescriptor
+        {
+            ClientId     = clientId,
+            ClientSecret = rawSecret,       // OpenIddict hashes this via PBKDF2 internally.
+            ClientType   = ClientTypes.Confidential,
+            ConsentType  = ConsentTypes.Implicit,
+            Permissions  =
+            {
+                Permissions.Endpoints.Authorization,
+                Permissions.Endpoints.Token,
+                Permissions.GrantTypes.AuthorizationCode,
+                Permissions.ResponseTypes.Code,
+                // Note: OpenIddict 7.5.0 does not have Permissions.Scopes.OpenId —
+                // the 'openid' scope is implicitly handled by the framework.
+                Permissions.Scopes.Profile,
+                Permissions.Scopes.Email,
+            },
+            RedirectUris = { new Uri(redirectUri) },
+            Requirements = { Requirements.Features.ProofKeyForCodeExchange },
+        };
+
+        if (!scopes.Contains("profile", StringComparer.OrdinalIgnoreCase))
+            descriptor.Permissions.Remove(Permissions.Scopes.Profile);
+        if (!scopes.Contains("email",   StringComparer.OrdinalIgnoreCase))
+            descriptor.Permissions.Remove(Permissions.Scopes.Email);
+
+        if (existing != null && update)
+            await manager.DeleteAsync(existing);
+
+        await manager.CreateAsync(descriptor);
+
+        Console.WriteLine($"Client '{clientId}' registered successfully.");
+        Console.WriteLine($"CLIENT_SECRET (copy now — will not be shown again): {rawSecret}");
+        return 0;
+    }
+
+    private static async Task<int> ListClients(IOpenIddictApplicationManager manager)
+    {
+        var count = 0;
+        await foreach (var app in manager.ListAsync())
+        {
+            var id = await manager.GetClientIdAsync(app);
+            Console.WriteLine($"  {id}");
+            count++;
+        }
+        Console.WriteLine($"Total: {count} client(s)");
+        return 0;
+    }
+
+    private static async Task<int> DeleteClient(string[] args, IOpenIddictApplicationManager manager)
+    {
+        string clientId = null;
+        for (int i = 1; i < args.Length; i++)
+            if (args[i] == "--client-id") clientId = args[++i];
+
+        if (string.IsNullOrEmpty(clientId))
+        {
+            Console.Error.WriteLine("ERROR: --client-id is required");
+            return 1;
+        }
+
+        var existing = await manager.FindByClientIdAsync(clientId);
+        if (existing == null)
+        {
+            Console.Error.WriteLine($"ERROR: Client '{clientId}' not found");
+            return 1;
+        }
+
+        await manager.DeleteAsync(existing);
+        Console.WriteLine($"Client '{clientId}' deleted.");
+        return 0;
+    }
+
+    private static int Usage()
+    {
+        Console.Error.WriteLine("Usage: register-client --client-id <id> --redirect-uri <uri> [--scopes openid,profile,email] [--update]");
+        Console.Error.WriteLine("       list-clients");
+        Console.Error.WriteLine("       delete-client --client-id <id>");
+        return 1;
+    }
+
+    private static IHost BuildCliHost(string[] args) =>
+        Host.CreateDefaultBuilder()
+            .ConfigureServices((_, services) =>
+            {
+                var appConfig = new AppConfig();
+                services.AddSingleton<IAppConfig>(appConfig);
+                services.AddSingleton(_ => new MongoClient(appConfig.MongoConnectionString));
+                services.AddOpenIddict()
+                    .AddCore(core =>
+                    {
+                        core.UseMongoDb(options =>
+                            options.UseDatabase(
+                                new MongoClient(appConfig.MongoConnectionString)
+                                    .GetDatabase(appConfig.DatabaseName)));
+                    });
+            })
+            .Build();
+}

--- a/W3ChampionsIdentificationService/Oidc/Cli/OidcClientCli.cs
+++ b/W3ChampionsIdentificationService/Oidc/Cli/OidcClientCli.cs
@@ -16,6 +16,9 @@ public static class OidcClientCli
 {
     public static async Task<int> RunAsync(string[] args)
     {
+        if (args.Length == 0)
+            return Usage();
+
         var subcommand = args[0];
         using var host = BuildCliHost(args);
         try

--- a/W3ChampionsIdentificationService/Oidc/Cli/OidcClientCli.cs
+++ b/W3ChampionsIdentificationService/Oidc/Cli/OidcClientCli.cs
@@ -20,7 +20,7 @@ public static class OidcClientCli
             return Usage();
 
         var subcommand = args[0];
-        using var host = BuildCliHost(args);
+        using var host = BuildCliHost();
         try
         {
             await host.StartAsync();
@@ -28,8 +28,8 @@ public static class OidcClientCli
             return subcommand switch
             {
                 "register-client" => await RegisterClient(args, manager),
-                "list-clients"    => await ListClients(manager),
-                "delete-client"   => await DeleteClient(args, manager),
+                "list-clients" => await ListClients(manager),
+                "delete-client" => await DeleteClient(args, manager),
                 _ => Usage()
             };
         }
@@ -79,14 +79,14 @@ public static class OidcClientCli
         {
             switch (args[i])
             {
-                case "--client-id":    clientId    = NextValue(args, ref i); break;
+                case "--client-id": clientId = NextValue(args, ref i); break;
                 case "--redirect-uri": redirectUri = NextValue(args, ref i); break;
-                case "--scopes":       scopes      = NextValue(args, ref i).Split(','); break;
-                case "--update":       update      = true; break;
+                case "--scopes": scopes = NextValue(args, ref i).Split(','); break;
+                case "--update": update = true; break;
             }
         }
 
-        if (string.IsNullOrEmpty(clientId))    throw new ArgumentException("--client-id is required");
+        if (string.IsNullOrEmpty(clientId)) throw new ArgumentException("--client-id is required");
         if (string.IsNullOrEmpty(redirectUri)) throw new ArgumentException("--redirect-uri is required");
         if (!IsValidHttpsRedirectUri(redirectUri))
             throw new ArgumentException($"redirect-uri must be an absolute HTTPS URL, got: {redirectUri}");
@@ -121,13 +121,13 @@ public static class OidcClientCli
 
         var descriptor = new OpenIddictApplicationDescriptor
         {
-            ClientId     = parsed.ClientId,
+            ClientId = parsed.ClientId,
             ClientSecret = rawSecret,       // OpenIddict hashes this via PBKDF2 internally.
-            ClientType   = ClientTypes.Confidential,
+            ClientType = ClientTypes.Confidential,
             // Implicit consent: Quackback is a first-party trusted client, so no consent
             // screen is shown (the IdP has no consent UI to render one).
-            ConsentType  = ConsentTypes.Implicit,
-            Permissions  =
+            ConsentType = ConsentTypes.Implicit,
+            Permissions =
             {
                 Permissions.Endpoints.Authorization,
                 Permissions.Endpoints.Token,
@@ -144,7 +144,7 @@ public static class OidcClientCli
 
         if (!parsed.Scopes.Contains("profile", StringComparer.OrdinalIgnoreCase))
             descriptor.Permissions.Remove(Permissions.Scopes.Profile);
-        if (!parsed.Scopes.Contains("email",   StringComparer.OrdinalIgnoreCase))
+        if (!parsed.Scopes.Contains("email", StringComparer.OrdinalIgnoreCase))
             descriptor.Permissions.Remove(Permissions.Scopes.Email);
 
         if (existing != null && parsed.Update)
@@ -207,7 +207,7 @@ public static class OidcClientCli
         return 1;
     }
 
-    private static IHost BuildCliHost(string[] args) =>
+    private static IHost BuildCliHost() =>
         Host.CreateDefaultBuilder()
             .ConfigureLogging(logging =>
             {

--- a/W3ChampionsIdentificationService/Oidc/HandoffJwtValidator.cs
+++ b/W3ChampionsIdentificationService/Oidc/HandoffJwtValidator.cs
@@ -51,15 +51,13 @@ public class HandoffJwtValidator
         {
             throw new HandoffValidationException("Token has expired", ex);
         }
+        catch (ArgumentException ex)   // null/empty/malformed token, bad base64url header (incl. SecurityTokenMalformedException)
+        {
+            throw new HandoffValidationException("Malformed token", ex);
+        }
         catch (SecurityTokenException ex)
         {
             throw new HandoffValidationException("Token validation failed", ex);
         }
     }
-}
-
-public class HandoffValidationException : Exception
-{
-    public HandoffValidationException(string message, Exception inner = null)
-        : base(message, inner) { }
 }

--- a/W3ChampionsIdentificationService/Oidc/HandoffJwtValidator.cs
+++ b/W3ChampionsIdentificationService/Oidc/HandoffJwtValidator.cs
@@ -1,0 +1,65 @@
+using System;
+using System.IdentityModel.Tokens.Jwt;
+using System.Linq;
+using System.Security.Cryptography;
+using Microsoft.IdentityModel.Tokens;
+
+namespace W3ChampionsIdentificationService.Oidc;
+
+/// <summary>
+/// Validates a w3c JWT (RS256, no iss/aud, with exp) presented at the handoff endpoint.
+/// Uses the same JWT_PUBLIC_KEY the rest of the service uses today — SEPARATE from the
+/// OIDC signing key.
+/// </summary>
+public class HandoffJwtValidator
+{
+    private readonly RsaSecurityKey _publicKey;
+
+    public HandoffJwtValidator(string rsaPemPublicKey)
+    {
+        var rsa = RSA.Create();
+        rsa.ImportFromPem(rsaPemPublicKey);
+        _publicKey = new RsaSecurityKey(rsa);
+    }
+
+    /// <summary>
+    /// Returns the battleTag extracted from the JWT, or throws <see cref="HandoffValidationException"/>
+    /// if the token is invalid, expired, or forged.
+    /// </summary>
+    public string ValidateAndExtractBattleTag(string jwt)
+    {
+        var parameters = new TokenValidationParameters
+        {
+            ValidateIssuer = false,
+            ValidateAudience = false,
+            ValidateLifetime = true,        // enforce exp — must NOT be ValidateLifetime=false
+            ValidateIssuerSigningKey = true,
+            IssuerSigningKey = _publicKey,
+            ClockSkew = TimeSpan.Zero,
+        };
+
+        try
+        {
+            var handler = new JwtSecurityTokenHandler();
+            var principal = handler.ValidateToken(jwt, parameters, out _);
+            var battleTag = principal.Claims.FirstOrDefault(c => c.Type == "battleTag")?.Value;
+            if (string.IsNullOrEmpty(battleTag))
+                throw new HandoffValidationException("battleTag claim missing");
+            return battleTag;
+        }
+        catch (SecurityTokenExpiredException ex)
+        {
+            throw new HandoffValidationException("Token has expired", ex);
+        }
+        catch (SecurityTokenException ex)
+        {
+            throw new HandoffValidationException("Token validation failed", ex);
+        }
+    }
+}
+
+public class HandoffValidationException : Exception
+{
+    public HandoffValidationException(string message, Exception inner = null)
+        : base(message, inner) { }
+}

--- a/W3ChampionsIdentificationService/Oidc/HandoffOriginValidator.cs
+++ b/W3ChampionsIdentificationService/Oidc/HandoffOriginValidator.cs
@@ -1,0 +1,44 @@
+using System;
+
+namespace W3ChampionsIdentificationService.Oidc;
+
+/// <summary>
+/// Login-CSRF defense for the handoff POST.
+///
+/// The legitimate handoff is auto-submitted from the website's /sso-continue page, so its
+/// Origin header is the website origin (= the origin of WEBSITE_LOGIN_URL). A cross-site
+/// attacker auto-submitting a forged JWT carries a different Origin, so rejecting POSTs whose
+/// Origin does not exactly match the website origin prevents session fixation: an attacker can
+/// no longer fixate the victim's browser with an IdP session for the attacker's BattleTag.
+/// </summary>
+public static class HandoffOriginValidator
+{
+    /// <summary>
+    /// Returns true only if <paramref name="requestOrigin"/> is non-empty and its scheme+host+port
+    /// exactly match the origin of <paramref name="websiteLoginUrl"/> (case-insensitive).
+    /// Returns false on null/empty/mismatch, or when either value is unparseable.
+    /// </summary>
+    public static bool IsAllowedOrigin(string requestOrigin, string websiteLoginUrl)
+    {
+        if (string.IsNullOrEmpty(requestOrigin))
+            return false;
+        if (string.IsNullOrEmpty(websiteLoginUrl))
+            return false;
+
+        if (!Uri.TryCreate(websiteLoginUrl, UriKind.Absolute, out var loginUri))
+            return false;
+        if (!Uri.TryCreate(requestOrigin, UriKind.Absolute, out var originUri))
+            return false;
+
+        // A real Origin header is a bare scheme+host+port with no path/query/fragment. Reject
+        // anything carrying a path (e.g. "https://site/evil") so an extra-path lookalike can't
+        // be folded onto the expected authority by GetLeftPart below.
+        if (originUri.AbsolutePath != "/" || !string.IsNullOrEmpty(originUri.Query) || !string.IsNullOrEmpty(originUri.Fragment))
+            return false;
+
+        var expectedOrigin = loginUri.GetLeftPart(UriPartial.Authority);
+        var actualOrigin = originUri.GetLeftPart(UriPartial.Authority);
+
+        return string.Equals(actualOrigin, expectedOrigin, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/W3ChampionsIdentificationService/Oidc/HandoffOriginValidator.cs
+++ b/W3ChampionsIdentificationService/Oidc/HandoffOriginValidator.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 namespace W3ChampionsIdentificationService.Oidc;
 
@@ -8,15 +9,24 @@ namespace W3ChampionsIdentificationService.Oidc;
 /// The legitimate handoff is auto-submitted from the website's /sso-continue page, so its
 /// Origin header is the website origin (= the origin of WEBSITE_LOGIN_URL). A cross-site
 /// attacker auto-submitting a forged JWT carries a different Origin, so rejecting POSTs whose
-/// Origin does not exactly match the website origin prevents session fixation: an attacker can
-/// no longer fixate the victim's browser with an IdP session for the attacker's BattleTag.
+/// Origin is not the website origin prevents session fixation: an attacker can no longer fixate
+/// the victim's browser with an IdP session for the attacker's BattleTag.
+///
+/// The w3champions site is reachable on BOTH the apex (https://w3champions.com) and www
+/// (https://www.w3champions.com). /sso-continue may be served from (or canonicalize to) either,
+/// so the allowed set is the configured origin AND its apex/www sibling (same scheme + port).
+/// This stays same-site — only the apex+www of the CONFIGURED host are accepted; any other host,
+/// scheme, port, or lookalike suffix is still rejected.
 /// </summary>
 public static class HandoffOriginValidator
 {
+    private const string WwwPrefix = "www.";
+
     /// <summary>
-    /// Returns true only if <paramref name="requestOrigin"/> is non-empty and its scheme+host+port
-    /// exactly match the origin of <paramref name="websiteLoginUrl"/> (case-insensitive).
-    /// Returns false on null/empty/mismatch, or when either value is unparseable.
+    /// Returns true only if <paramref name="requestOrigin"/> is a bare origin (no path/query/fragment)
+    /// whose scheme+host+port (case-insensitive) matches the origin of <paramref name="websiteLoginUrl"/>
+    /// OR that origin's apex/www sibling. Returns false on null/empty/mismatch, or when either value
+    /// is unparseable.
     /// </summary>
     public static bool IsAllowedOrigin(string requestOrigin, string websiteLoginUrl)
     {
@@ -32,13 +42,40 @@ public static class HandoffOriginValidator
 
         // A real Origin header is a bare scheme+host+port with no path/query/fragment. Reject
         // anything carrying a path (e.g. "https://site/evil") so an extra-path lookalike can't
-        // be folded onto the expected authority by GetLeftPart below.
+        // be folded onto an allowed authority by GetLeftPart below.
         if (originUri.AbsolutePath != "/" || !string.IsNullOrEmpty(originUri.Query) || !string.IsNullOrEmpty(originUri.Fragment))
             return false;
 
-        var expectedOrigin = loginUri.GetLeftPart(UriPartial.Authority);
         var actualOrigin = originUri.GetLeftPart(UriPartial.Authority);
 
-        return string.Equals(actualOrigin, expectedOrigin, StringComparison.OrdinalIgnoreCase);
+        foreach (var allowed in AllowedOriginsFor(loginUri))
+        {
+            if (string.Equals(actualOrigin, allowed, StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// The configured origin plus its apex/www sibling (same scheme + port). If the host begins
+    /// with "www.", the sibling drops it; otherwise the sibling prepends "www.".
+    /// </summary>
+    private static IEnumerable<string> AllowedOriginsFor(Uri loginUri)
+    {
+        var configured = loginUri.GetLeftPart(UriPartial.Authority);
+        yield return configured;
+
+        var host = loginUri.Host;
+        var siblingHost = host.StartsWith(WwwPrefix, StringComparison.OrdinalIgnoreCase)
+            ? host.Substring(WwwPrefix.Length)
+            : WwwPrefix + host;
+
+        // Rebuild the sibling origin preserving scheme + (non-default) port.
+        var siblingBuilder = new UriBuilder(loginUri.Scheme, siblingHost);
+        if (!loginUri.IsDefaultPort)
+            siblingBuilder.Port = loginUri.Port;
+
+        yield return siblingBuilder.Uri.GetLeftPart(UriPartial.Authority);
     }
 }

--- a/W3ChampionsIdentificationService/Oidc/HandoffReturnUrlValidator.cs
+++ b/W3ChampionsIdentificationService/Oidc/HandoffReturnUrlValidator.cs
@@ -1,0 +1,39 @@
+using System;
+
+namespace W3ChampionsIdentificationService.Oidc;
+
+/// <summary>
+/// Validates the `return` parameter in a handoff POST.
+/// The only permitted origins are the prod and test identification-service hosts
+/// (exact origin match, no subdomain wildcard).
+/// </summary>
+public static class HandoffReturnUrlValidator
+{
+    private static readonly string[] AllowedOrigins =
+    [
+        "https://identification-service.w3champions.com",
+        "https://identification-service.test.w3champions.com",
+    ];
+
+    /// <summary>
+    /// Returns true if <paramref name="returnUrl"/> is an absolute HTTPS URL
+    /// whose scheme+host+port exactly match one of the allowed origins.
+    /// </summary>
+    public static bool IsAllowed(string returnUrl)
+    {
+        if (string.IsNullOrEmpty(returnUrl))
+            return false;
+        if (!Uri.TryCreate(returnUrl, UriKind.Absolute, out var uri))
+            return false;
+        if (!string.Equals(uri.Scheme, "https", StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        var origin = uri.GetLeftPart(UriPartial.Authority);
+        foreach (var allowed in AllowedOrigins)
+        {
+            if (string.Equals(origin, allowed, StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+        return false;
+    }
+}

--- a/W3ChampionsIdentificationService/Oidc/HandoffReturnUrlValidator.cs
+++ b/W3ChampionsIdentificationService/Oidc/HandoffReturnUrlValidator.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 namespace W3ChampionsIdentificationService.Oidc;
 
@@ -9,11 +10,17 @@ namespace W3ChampionsIdentificationService.Oidc;
 /// </summary>
 public static class HandoffReturnUrlValidator
 {
-    private static readonly string[] AllowedOrigins =
+    private static readonly string[] _allowed =
     [
         "https://identification-service.w3champions.com",
         "https://identification-service.test.w3champions.com",
     ];
+
+    /// <summary>
+    /// The origins that are permitted as handoff return-URL origins.
+    /// Exposed so Startup can check that <c>OIDC_ISSUER</c> is among them and warn if not.
+    /// </summary>
+    public static IReadOnlyList<string> AllowedOrigins => _allowed;
 
     /// <summary>
     /// Returns true if <paramref name="returnUrl"/> is an absolute HTTPS URL
@@ -29,7 +36,7 @@ public static class HandoffReturnUrlValidator
             return false;
 
         var origin = uri.GetLeftPart(UriPartial.Authority);
-        foreach (var allowed in AllowedOrigins)
+        foreach (var allowed in _allowed)
         {
             if (string.Equals(origin, allowed, StringComparison.OrdinalIgnoreCase))
                 return true;

--- a/W3ChampionsIdentificationService/Oidc/HandoffValidationException.cs
+++ b/W3ChampionsIdentificationService/Oidc/HandoffValidationException.cs
@@ -5,8 +5,6 @@ namespace W3ChampionsIdentificationService.Oidc;
 /// <summary>
 /// Thrown when a w3c handoff JWT fails validation (missing, malformed, expired, forged, or tampered).
 /// </summary>
-public class HandoffValidationException : Exception
+public class HandoffValidationException(string message, Exception inner = null) : Exception(message, inner)
 {
-    public HandoffValidationException(string message, Exception inner = null)
-        : base(message, inner) { }
 }

--- a/W3ChampionsIdentificationService/Oidc/HandoffValidationException.cs
+++ b/W3ChampionsIdentificationService/Oidc/HandoffValidationException.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace W3ChampionsIdentificationService.Oidc;
+
+/// <summary>
+/// Thrown when a w3c handoff JWT fails validation (missing, malformed, expired, forged, or tampered).
+/// </summary>
+public class HandoffValidationException : Exception
+{
+    public HandoffValidationException(string message, Exception inner = null)
+        : base(message, inner) { }
+}

--- a/W3ChampionsIdentificationService/Oidc/OidcAuthorizeController.cs
+++ b/W3ChampionsIdentificationService/Oidc/OidcAuthorizeController.cs
@@ -33,15 +33,23 @@ public class OidcAuthorizeController(IAppConfig appConfig) : ControllerBase
         if (!result.Succeeded || result.Principal == null)
         {
             // No IdP session — redirect the browser to the website for interactive login.
-            var selfAbsoluteUrl = $"{Request.Scheme}://{Request.Host}{Request.Path}{Request.QueryString}";
+            // Build the self URL from the canonical, startup-validated OIDC issuer rather than
+            // Request.Host: behind the Traefik→nginx-proxy chain X-Forwarded-Host is NOT trusted
+            // (Startup only forwards For/Proto), so Request.Host is the internal Docker host. The
+            // query string carries client_id/redirect_uri/scope/state/PKCE and is preserved; OpenIddict
+            // re-parses the request from the query, not the host.
+            var issuerBase = _appConfig.OidcIssuer.TrimEnd('/');   // guard against a trailing slash → "//connect"
+            var selfAbsoluteUrl = $"{issuerBase}{Request.Path}{Request.QueryString}";
             var redirectUrl = $"{_appConfig.WebsiteLoginUrl}?return={HttpUtility.UrlEncode(selfAbsoluteUrl)}";
 
-            Log.Information("No IdP session — redirecting to website login at {RedirectUrl}", redirectUrl);
+            Log.Information("No IdP session for client {ClientId} — redirecting to website login {LoginUrl}", oidcRequest.ClientId, _appConfig.WebsiteLoginUrl);
             return Redirect(redirectUrl);
         }
 
         var battleTag = result.Principal.FindFirstValue("battleTag")
             ?? throw new InvalidOperationException("battleTag claim missing from IdP session");
+
+        var scopes = oidcRequest.GetScopes();
 
         var identity = new ClaimsIdentity(
             authenticationType: OpenIddictServerAspNetCoreDefaults.AuthenticationScheme,
@@ -49,9 +57,13 @@ public class OidcAuthorizeController(IAppConfig appConfig) : ControllerBase
             roleType: Claims.Role);
 
         identity.AddClaim(Claims.Subject, battleTag);
-        identity.AddClaim(Claims.Name, battleTag); // full battletag (incl. #discriminator) as display name — keeps users identifiable
-        identity.AddClaim(Claims.Email, OidcClaimMapper.BattleTagToSyntheticEmail(battleTag));
-        identity.AddClaim(Claims.EmailVerified, "false");
+        if (scopes.Contains(Scopes.Profile))
+            identity.AddClaim(Claims.Name, battleTag); // full battletag (incl. #discriminator) — keeps users identifiable
+        if (scopes.Contains(Scopes.Email))
+        {
+            identity.AddClaim(Claims.Email, OidcClaimMapper.BattleTagToSyntheticEmail(battleTag));
+            identity.AddClaim(new Claim(Claims.EmailVerified, "false", ClaimValueTypes.Boolean)); // typed bool → serialized as JSON false, matching userinfo
+        }
 
         identity.SetDestinations(claim => claim.Type switch
         {
@@ -63,7 +75,7 @@ public class OidcAuthorizeController(IAppConfig appConfig) : ControllerBase
         });
 
         var principal = new ClaimsPrincipal(identity);
-        principal.SetScopes(oidcRequest.GetScopes());
+        principal.SetScopes(scopes);
 
         return SignIn(principal, OpenIddictServerAspNetCoreDefaults.AuthenticationScheme);
     }

--- a/W3ChampionsIdentificationService/Oidc/OidcAuthorizeController.cs
+++ b/W3ChampionsIdentificationService/Oidc/OidcAuthorizeController.cs
@@ -118,7 +118,15 @@ public class OidcAuthorizeController(IAppConfig appConfig) : ControllerBase
             identity.AddClaim(new Claim(Claims.EmailVerified, "false", ClaimValueTypes.Boolean)); // typed bool → serialized as JSON false, matching userinfo
         }
 
-        identity.SetDestinations(claim => claim.Type switch
+        var principal = new ClaimsPrincipal(identity);
+
+        // Order matters: SetScopes FIRST so it adds the private scope claims (oi_scp), THEN assign
+        // destinations over the FULL claim set (principal-level SetDestinations iterates all claims).
+        // Otherwise the oi_scp claims, added after destination assignment, would get no destination
+        // and be omitted from the access token — leaving OidcUserInfoController.GetScopes() empty so
+        // userinfo drops name/email. The `_ => AccessToken` default routes oi_scp into the access token.
+        principal.SetScopes(scopes);
+        principal.SetDestinations(claim => claim.Type switch
         {
             Claims.Subject => new[] { Destinations.AccessToken, Destinations.IdentityToken },
             Claims.Name => new[] { Destinations.IdentityToken },
@@ -126,9 +134,6 @@ public class OidcAuthorizeController(IAppConfig appConfig) : ControllerBase
             Claims.EmailVerified => new[] { Destinations.IdentityToken },
             _ => new[] { Destinations.AccessToken }
         });
-
-        var principal = new ClaimsPrincipal(identity);
-        principal.SetScopes(scopes);
 
         return SignIn(principal, OpenIddictServerAspNetCoreDefaults.AuthenticationScheme);
     }

--- a/W3ChampionsIdentificationService/Oidc/OidcAuthorizeController.cs
+++ b/W3ChampionsIdentificationService/Oidc/OidcAuthorizeController.cs
@@ -32,18 +32,34 @@ public class OidcAuthorizeController(IAppConfig appConfig) : ControllerBase
         var oidcRequest = HttpContext.GetOpenIddictServerRequest()
             ?? throw new InvalidOperationException("OpenIddict request not available");
 
-        // Check for an existing IdP session cookie.
+        // Check for an existing IdP session cookie and resolve the prompt directives together so
+        // the none/login handling stays coherent.
         var result = await HttpContext.AuthenticateAsync(
             CookieAuthenticationDefaults.AuthenticationScheme);
+        var hasSession = result.Succeeded && result.Principal != null;
+        var promptNone = oidcRequest.HasPromptValue(PromptValues.None);
+        var promptLogin = oidcRequest.HasPromptValue(PromptValues.Login);
 
-        if (!result.Succeeded || result.Principal == null)
+        // prompt=login forces reauthentication: discard any existing IdP session so the user is
+        // sent back through login (account switch / fresh login) instead of being silently served
+        // the previous BattleTag.
+        if (promptLogin && hasSession)
+        {
+            await HttpContext.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
+            Log.Information("prompt=login for client {ClientId} — cleared existing IdP session to force reauthentication", oidcRequest.ClientId);
+            hasSession = false;
+        }
+
+        if (!hasSession)
         {
             // OIDC silent auth: a prompt=none authorize request with no IdP session must NOT
             // trigger interactive login. Per the spec it returns an immediate login_required
             // error to the client's redirect_uri (silent-auth callers expect this, never an
             // interactive redirect). OpenIddict translates this Forbid into the standard error
-            // response on the token/authorize channel.
-            if (oidcRequest.HasPromptValue(PromptValues.None))
+            // response on the token/authorize channel. (prompt=none with prompt=login is a
+            // contradictory request; we honor prompt=none here and return login_required rather
+            // than redirecting to interactive login.)
+            if (promptNone)
             {
                 Log.Information("prompt=none with no IdP session for client {ClientId} — returning login_required", oidcRequest.ClientId);
                 return Forbid(

--- a/W3ChampionsIdentificationService/Oidc/OidcAuthorizeController.cs
+++ b/W3ChampionsIdentificationService/Oidc/OidcAuthorizeController.cs
@@ -72,11 +72,11 @@ public class OidcAuthorizeController(IAppConfig appConfig) : ControllerBase
 
         identity.SetDestinations(claim => claim.Type switch
         {
-            Claims.Subject       => new[] { Destinations.AccessToken, Destinations.IdentityToken },
-            Claims.Name          => new[] { Destinations.IdentityToken },
-            Claims.Email         => new[] { Destinations.IdentityToken },
+            Claims.Subject => new[] { Destinations.AccessToken, Destinations.IdentityToken },
+            Claims.Name => new[] { Destinations.IdentityToken },
+            Claims.Email => new[] { Destinations.IdentityToken },
             Claims.EmailVerified => new[] { Destinations.IdentityToken },
-            _                    => new[] { Destinations.AccessToken }
+            _ => new[] { Destinations.AccessToken }
         });
 
         var principal = new ClaimsPrincipal(identity);

--- a/W3ChampionsIdentificationService/Oidc/OidcAuthorizeController.cs
+++ b/W3ChampionsIdentificationService/Oidc/OidcAuthorizeController.cs
@@ -19,8 +19,13 @@ public class OidcAuthorizeController(IAppConfig appConfig) : ControllerBase
 {
     private readonly IAppConfig _appConfig = appConfig;
 
+    // GET-only: OIDC relying parties (including Better Auth / Quackback) initiate the
+    // authorization request via a GET redirect. OIDC params live in the query string, which
+    // the website-handoff resume URL ($"{issuerBase}{Request.Path}{Request.QueryString}")
+    // already preserves. POST support is dropped because form-body params are NOT included
+    // in that resume URL, so the resumed GET would arrive with no client_id/redirect_uri/
+    // scope/state/PKCE and OpenIddict would reject the flow.
     [HttpGet("~/connect/authorize")]
-    [HttpPost("~/connect/authorize")]
     public async Task<IActionResult> Authorize()
     {
         var oidcRequest = HttpContext.GetOpenIddictServerRequest()

--- a/W3ChampionsIdentificationService/Oidc/OidcAuthorizeController.cs
+++ b/W3ChampionsIdentificationService/Oidc/OidcAuthorizeController.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using System.Web;
+using Microsoft.AspNetCore;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Mvc;
+using OpenIddict.Abstractions;
+using OpenIddict.Server.AspNetCore;
+using Serilog;
+using W3ChampionsIdentificationService.Config;
+using static OpenIddict.Abstractions.OpenIddictConstants;
+
+namespace W3ChampionsIdentificationService.Oidc;
+
+[ApiController]
+public class OidcAuthorizeController(IAppConfig appConfig) : ControllerBase
+{
+    private readonly IAppConfig _appConfig = appConfig;
+
+    [HttpGet("~/connect/authorize")]
+    [HttpPost("~/connect/authorize")]
+    public async Task<IActionResult> Authorize()
+    {
+        var oidcRequest = HttpContext.GetOpenIddictServerRequest()
+            ?? throw new InvalidOperationException("OpenIddict request not available");
+
+        // Check for an existing IdP session cookie.
+        var result = await HttpContext.AuthenticateAsync(
+            CookieAuthenticationDefaults.AuthenticationScheme);
+
+        if (!result.Succeeded || result.Principal == null)
+        {
+            // No IdP session — redirect the browser to the website for interactive login.
+            var selfAbsoluteUrl = $"{Request.Scheme}://{Request.Host}{Request.Path}{Request.QueryString}";
+            var redirectUrl = $"{_appConfig.WebsiteLoginUrl}?return={HttpUtility.UrlEncode(selfAbsoluteUrl)}";
+
+            Log.Information("No IdP session — redirecting to website login at {RedirectUrl}", redirectUrl);
+            return Redirect(redirectUrl);
+        }
+
+        var battleTag = result.Principal.FindFirstValue("battleTag")
+            ?? throw new InvalidOperationException("battleTag claim missing from IdP session");
+
+        var identity = new ClaimsIdentity(
+            authenticationType: OpenIddictServerAspNetCoreDefaults.AuthenticationScheme,
+            nameType: Claims.Name,
+            roleType: Claims.Role);
+
+        identity.AddClaim(Claims.Subject, battleTag);
+        identity.AddClaim(Claims.Name, battleTag); // full battletag (incl. #discriminator) as display name — keeps users identifiable
+        identity.AddClaim(Claims.Email, OidcClaimMapper.BattleTagToSyntheticEmail(battleTag));
+        identity.AddClaim(Claims.EmailVerified, "false");
+
+        identity.SetDestinations(claim => claim.Type switch
+        {
+            Claims.Subject       => new[] { Destinations.AccessToken, Destinations.IdentityToken },
+            Claims.Name          => new[] { Destinations.IdentityToken },
+            Claims.Email         => new[] { Destinations.IdentityToken },
+            Claims.EmailVerified => new[] { Destinations.IdentityToken },
+            _                    => new[] { Destinations.AccessToken }
+        });
+
+        var principal = new ClaimsPrincipal(identity);
+        principal.SetScopes(oidcRequest.GetScopes());
+
+        return SignIn(principal, OpenIddictServerAspNetCoreDefaults.AuthenticationScheme);
+    }
+}

--- a/W3ChampionsIdentificationService/Oidc/OidcAuthorizeController.cs
+++ b/W3ChampionsIdentificationService/Oidc/OidcAuthorizeController.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using System.Web;
@@ -37,6 +38,23 @@ public class OidcAuthorizeController(IAppConfig appConfig) : ControllerBase
 
         if (!result.Succeeded || result.Principal == null)
         {
+            // OIDC silent auth: a prompt=none authorize request with no IdP session must NOT
+            // trigger interactive login. Per the spec it returns an immediate login_required
+            // error to the client's redirect_uri (silent-auth callers expect this, never an
+            // interactive redirect). OpenIddict translates this Forbid into the standard error
+            // response on the token/authorize channel.
+            if (oidcRequest.HasPromptValue(PromptValues.None))
+            {
+                Log.Information("prompt=none with no IdP session for client {ClientId} — returning login_required", oidcRequest.ClientId);
+                return Forbid(
+                    authenticationSchemes: OpenIddictServerAspNetCoreDefaults.AuthenticationScheme,
+                    properties: new AuthenticationProperties(new Dictionary<string, string>
+                    {
+                        [OpenIddictServerAspNetCoreConstants.Properties.Error] = Errors.LoginRequired,
+                        [OpenIddictServerAspNetCoreConstants.Properties.ErrorDescription] = "The user is not logged in.",
+                    }));
+            }
+
             // No IdP session — redirect the browser to the website for interactive login.
             // Build the self URL from the canonical, startup-validated OIDC issuer rather than
             // Request.Host: behind the Traefik→nginx-proxy chain X-Forwarded-Host is NOT trusted

--- a/W3ChampionsIdentificationService/Oidc/OidcAuthorizeController.cs
+++ b/W3ChampionsIdentificationService/Oidc/OidcAuthorizeController.cs
@@ -1,12 +1,15 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using System.Web;
 using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.WebUtilities;
 using OpenIddict.Abstractions;
 using OpenIddict.Server.AspNetCore;
 using Serilog;
@@ -77,8 +80,19 @@ public class OidcAuthorizeController(IAppConfig appConfig) : ControllerBase
             // (Startup only forwards For/Proto), so Request.Host is the internal Docker host. The
             // query string carries client_id/redirect_uri/scope/state/PKCE and is preserved; OpenIddict
             // re-parses the request from the query, not the host.
+            //
+            // STRIP `prompt` from the return URL: prompt=login means "force reauth ONCE". If we kept
+            // it, the post-handoff continuation would still carry prompt=login → we'd sign out the
+            // freshly-set session and redirect again → infinite loop. Removing it means the resumed
+            // request has no prompt, so the controller then sees hasSession && !promptLogin and issues
+            // the code. This service only handles prompt=none/login and has no consent screen
+            // (ConsentType.Implicit), so there's no prompt=consent semantics to preserve.
+            var query = QueryHelpers.ParseQuery(Request.QueryString.Value ?? "");
+            query.Remove("prompt");
+            var strippedQuery = QueryString.Create(
+                query.SelectMany(kv => kv.Value.Select(v => new KeyValuePair<string, string>(kv.Key, v))));
             var issuerBase = _appConfig.OidcIssuer.TrimEnd('/');   // guard against a trailing slash → "//connect"
-            var selfAbsoluteUrl = $"{issuerBase}{Request.Path}{Request.QueryString}";
+            var selfAbsoluteUrl = $"{issuerBase}{Request.Path}{strippedQuery}";
             var redirectUrl = $"{_appConfig.WebsiteLoginUrl}?return={HttpUtility.UrlEncode(selfAbsoluteUrl)}";
 
             Log.Information("No IdP session for client {ClientId} — redirecting to website login {LoginUrl}", oidcRequest.ClientId, _appConfig.WebsiteLoginUrl);

--- a/W3ChampionsIdentificationService/Oidc/OidcClaimMapper.cs
+++ b/W3ChampionsIdentificationService/Oidc/OidcClaimMapper.cs
@@ -1,4 +1,7 @@
 using System;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.RegularExpressions;
 
 namespace W3ChampionsIdentificationService.Oidc;
 
@@ -14,6 +17,8 @@ public static class OidcClaimMapper
     // a GENERIC IdP behaviour (no relying-party name appears here).
     private const string SyntheticEmailDomain = "w3champions.invalid";
 
+    private static readonly Regex SafeLocalPart = new("^[a-z0-9._-]+$", RegexOptions.Compiled);
+
     /// <summary>
     /// Derives a synthetic, non-deliverable email for a w3c identity that has no
     /// real email, used when an OIDC client requests the `email` scope. Replaces
@@ -24,7 +29,26 @@ public static class OidcClaimMapper
     {
         if (string.IsNullOrEmpty(battleTag))
             throw new ArgumentException("battleTag must not be empty", nameof(battleTag));
-        var localPart = battleTag.Replace('#', '-').ToLowerInvariant();
+
+        var candidate = battleTag.Replace('#', '-').ToLowerInvariant();
+        // Normal ASCII battletags keep a readable local-part (e.g. "modmoto-2809").
+        // Anything with non-ASCII / unsafe chars falls back to a deterministic,
+        // collision-free ASCII local-part derived from a hash of the ORIGINAL battletag,
+        // so the email is always RFC-5321-legal and unique per identity. (The human-
+        // readable identity is the `name` claim = full battletag, not this email.)
+        var localPart = SafeLocalPart.IsMatch(candidate)
+            ? candidate
+            : "u-" + Sha256Hex(battleTag);
+
         return $"{localPart}@{SyntheticEmailDomain}";
+    }
+
+    private static string Sha256Hex(string input)
+    {
+        var hash = SHA256.HashData(Encoding.UTF8.GetBytes(input));
+        var sb = new StringBuilder(32);
+        for (int i = 0; i < 16; i++)            // 16 bytes -> 128 bits -> 32 hex chars
+            sb.Append(hash[i].ToString("x2"));
+        return sb.ToString();
     }
 }

--- a/W3ChampionsIdentificationService/Oidc/OidcClaimMapper.cs
+++ b/W3ChampionsIdentificationService/Oidc/OidcClaimMapper.cs
@@ -1,0 +1,30 @@
+using System;
+
+namespace W3ChampionsIdentificationService.Oidc;
+
+/// <summary>
+/// Maps a w3c battleTag to the OIDC claims released to a relying-party client.
+/// </summary>
+public static class OidcClaimMapper
+{
+    // Generic, non-deliverable domain for identities with no real email.
+    // The reserved ".invalid" TLD (RFC 6761) guarantees the address is never
+    // routable — we are NOT minting real/valid emails, only a unique, stable
+    // identifier to satisfy OIDC clients that require an email claim. This is
+    // a GENERIC IdP behaviour (no relying-party name appears here).
+    private const string SyntheticEmailDomain = "w3champions.invalid";
+
+    /// <summary>
+    /// Derives a synthetic, non-deliverable email for a w3c identity that has no
+    /// real email, used when an OIDC client requests the `email` scope. Replaces
+    /// '#' with '-' so the local-part is RFC-5321 legal.
+    /// Example: "Modmoto#2809" → "modmoto-2809@w3champions.invalid"
+    /// </summary>
+    public static string BattleTagToSyntheticEmail(string battleTag)
+    {
+        if (string.IsNullOrEmpty(battleTag))
+            throw new ArgumentException("battleTag must not be empty", nameof(battleTag));
+        var localPart = battleTag.Replace('#', '-').ToLowerInvariant();
+        return $"{localPart}@{SyntheticEmailDomain}";
+    }
+}

--- a/W3ChampionsIdentificationService/Oidc/OidcHandoffController.cs
+++ b/W3ChampionsIdentificationService/Oidc/OidcHandoffController.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Mvc;
 using Serilog;
+using W3ChampionsIdentificationService.Config;
 
 namespace W3ChampionsIdentificationService.Oidc;
 
@@ -15,8 +16,10 @@ namespace W3ChampionsIdentificationService.Oidc;
 /// cookie, then 302-redirects back to /connect/authorize to complete the OIDC flow.
 /// </summary>
 [ApiController]
-public class OidcHandoffController : ControllerBase
+public class OidcHandoffController(IAppConfig appConfig) : ControllerBase
 {
+    private readonly IAppConfig _appConfig = appConfig;
+
     private static readonly string JwtPublicKey =
         Regex.Unescape(Environment.GetEnvironmentVariable("JWT_PUBLIC_KEY") ?? "");
 
@@ -29,6 +32,17 @@ public class OidcHandoffController : ControllerBase
     [Consumes("application/x-www-form-urlencoded")]
     public async Task<IActionResult> Handoff([FromForm] HandoffRequest request)
     {
+        // Login-CSRF defense (FIRST check): the legitimate handoff is auto-submitted from the
+        // website's /sso-continue page, so its Origin is the website origin. A cross-site page
+        // auto-submitting an attacker-controlled JWT carries a foreign Origin — reject it before
+        // touching the token, so it can never fixate an IdP session for the attacker's BattleTag.
+        var origin = Request.Headers.Origin.ToString();
+        if (!HandoffOriginValidator.IsAllowedOrigin(origin, _appConfig.WebsiteLoginUrl))
+        {
+            Log.Warning("Handoff rejected: Origin '{Origin}' does not match the website login origin", origin);
+            return BadRequest("invalid origin");
+        }
+
         if (string.IsNullOrEmpty(request.Jwt))
         {
             Log.Warning("Handoff called without jwt form field");

--- a/W3ChampionsIdentificationService/Oidc/OidcHandoffController.cs
+++ b/W3ChampionsIdentificationService/Oidc/OidcHandoffController.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Security.Claims;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Mvc;
+using Serilog;
+
+namespace W3ChampionsIdentificationService.Oidc;
+
+/// <summary>
+/// POST /connect/handoff
+/// Accepts the w3c JWT from the website, validates it, establishes the IdP session
+/// cookie, then 302-redirects back to /connect/authorize to complete the OIDC flow.
+/// </summary>
+[ApiController]
+public class OidcHandoffController : ControllerBase
+{
+    private static readonly string JwtPublicKey =
+        Regex.Unescape(Environment.GetEnvironmentVariable("JWT_PUBLIC_KEY") ?? "");
+
+    // Parse the public key once for the process (thread-safe). Avoids per-request
+    // native RSA allocation / PEM re-parsing on the SSO hot path.
+    private static readonly Lazy<HandoffJwtValidator> Validator =
+        new(() => new HandoffJwtValidator(JwtPublicKey));
+
+    [HttpPost("~/connect/handoff")]
+    [Consumes("application/x-www-form-urlencoded")]
+    public async Task<IActionResult> Handoff([FromForm] HandoffRequest request)
+    {
+        if (string.IsNullOrEmpty(request.Jwt))
+        {
+            Log.Warning("Handoff called without jwt form field");
+            return BadRequest("jwt is required");
+        }
+
+        if (!HandoffReturnUrlValidator.IsAllowed(request.Return))
+        {
+            Log.Warning("Handoff called with disallowed return URL: {Return}", request.Return);
+            return BadRequest("return URL is not allowed");
+        }
+
+        string battleTag;
+        try
+        {
+            battleTag = Validator.Value.ValidateAndExtractBattleTag(request.Jwt);
+        }
+        catch (HandoffValidationException ex)
+        {
+            Log.Warning("Handoff JWT validation failed: {Message}", ex.Message);
+            return Unauthorized("Invalid or expired token");
+        }
+
+        // Establish the IdP session cookie.
+        var identity = new ClaimsIdentity(CookieAuthenticationDefaults.AuthenticationScheme);
+        identity.AddClaim(new Claim("battleTag", battleTag));
+
+        var principal = new ClaimsPrincipal(identity);
+        await HttpContext.SignInAsync(
+            CookieAuthenticationDefaults.AuthenticationScheme,
+            principal,
+            new AuthenticationProperties { IsPersistent = false });
+
+        Log.Information("IdP session established for {BattleTag}, resuming OIDC flow", battleTag);
+
+        return Redirect(request.Return);
+    }
+}
+
+public class HandoffRequest
+{
+    public string Jwt { get; set; }
+    public string Return { get; set; }
+}

--- a/W3ChampionsIdentificationService/Oidc/OidcUserInfoController.cs
+++ b/W3ChampionsIdentificationService/Oidc/OidcUserInfoController.cs
@@ -32,7 +32,7 @@ public class OidcUserInfoController : ControllerBase
         // in the authorize controller. OpenIddict 7.5.0 stores scopes as individual `oi_scp`
         // claims in the JWT and GetScopes(ClaimsPrincipal) reads them back reliably.
         var principal = result.Principal;
-        var sub    = principal.FindFirstValue(Claims.Subject);   // = battleTag
+        var sub = principal.FindFirstValue(Claims.Subject);   // = battleTag
         var scopes = principal.GetScopes();                       // granted scopes from the access token
 
         var response = new Dictionary<string, object> { ["sub"] = sub };
@@ -40,7 +40,7 @@ public class OidcUserInfoController : ControllerBase
             response["name"] = sub;                               // name = full battletag (incl. #discriminator)
         if (scopes.Contains(Scopes.Email))
         {
-            response["email"]          = OidcClaimMapper.BattleTagToSyntheticEmail(sub);
+            response["email"] = OidcClaimMapper.BattleTagToSyntheticEmail(sub);
             response["email_verified"] = false;
         }
         return Ok(response);

--- a/W3ChampionsIdentificationService/Oidc/OidcUserInfoController.cs
+++ b/W3ChampionsIdentificationService/Oidc/OidcUserInfoController.cs
@@ -1,0 +1,36 @@
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Mvc;
+using OpenIddict.Server.AspNetCore;
+using static OpenIddict.Abstractions.OpenIddictConstants;
+
+namespace W3ChampionsIdentificationService.Oidc;
+
+[ApiController]
+public class OidcUserInfoController : ControllerBase
+{
+    [HttpGet("~/connect/userinfo")]
+    [HttpPost("~/connect/userinfo")]
+    public async Task<IActionResult> UserInfo()
+    {
+        var result = await HttpContext.AuthenticateAsync(
+            OpenIddictServerAspNetCoreDefaults.AuthenticationScheme);
+
+        if (result?.Principal == null)
+            return Challenge(OpenIddictServerAspNetCoreDefaults.AuthenticationScheme);
+
+        var principal = result.Principal;
+        var sub   = principal.FindFirstValue(Claims.Subject);
+        var name  = principal.FindFirstValue(Claims.Name);
+        var email = principal.FindFirstValue(Claims.Email);
+
+        return Ok(new
+        {
+            sub,
+            name,
+            email,
+            email_verified = false,
+        });
+    }
+}

--- a/W3ChampionsIdentificationService/Oidc/OidcUserInfoController.cs
+++ b/W3ChampionsIdentificationService/Oidc/OidcUserInfoController.cs
@@ -1,7 +1,9 @@
+using System.Collections.Generic;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Mvc;
+using OpenIddict.Abstractions;
 using OpenIddict.Server.AspNetCore;
 using static OpenIddict.Abstractions.OpenIddictConstants;
 
@@ -20,17 +22,27 @@ public class OidcUserInfoController : ControllerBase
         if (result?.Principal == null)
             return Challenge(OpenIddictServerAspNetCoreDefaults.AuthenticationScheme);
 
+        // The userinfo endpoint is authenticated via the access token, which carries only
+        // `sub` as a standard claim (name/email destinations are IdentityToken-only — see
+        // OidcAuthorizeController.SetDestinations). Re-derive the claims from `sub` (the
+        // battleTag) gated on the scopes the access token was actually granted, mirroring
+        // the authorize-endpoint gating.
+        //
+        // GetScopes() reads the `oi_scp` claims embedded in the access token by SetScopes()
+        // in the authorize controller. OpenIddict 7.5.0 stores scopes as individual `oi_scp`
+        // claims in the JWT and GetScopes(ClaimsPrincipal) reads them back reliably.
         var principal = result.Principal;
-        var sub   = principal.FindFirstValue(Claims.Subject);
-        var name  = principal.FindFirstValue(Claims.Name);
-        var email = principal.FindFirstValue(Claims.Email);
+        var sub    = principal.FindFirstValue(Claims.Subject);   // = battleTag
+        var scopes = principal.GetScopes();                       // granted scopes from the access token
 
-        return Ok(new
+        var response = new Dictionary<string, object> { ["sub"] = sub };
+        if (scopes.Contains(Scopes.Profile))
+            response["name"] = sub;                               // name = full battletag (incl. #discriminator)
+        if (scopes.Contains(Scopes.Email))
         {
-            sub,
-            name,
-            email,
-            email_verified = false,
-        });
+            response["email"]          = OidcClaimMapper.BattleTagToSyntheticEmail(sub);
+            response["email_verified"] = false;
+        }
+        return Ok(response);
     }
 }

--- a/W3ChampionsIdentificationService/Program.cs
+++ b/W3ChampionsIdentificationService/Program.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Hosting;
 using Serilog;
@@ -8,7 +10,7 @@ namespace W3ChampionsIdentificationService;
 
 public class Program
 {
-    public static void Main(string[] args)
+    public static async Task Main(string[] args)
     {
         Log.Logger = new LoggerConfiguration()
             .MinimumLevel.Debug()
@@ -18,6 +20,15 @@ public class Program
             .MinimumLevel.Override("System.Net.Http", LogEventLevel.Warning) // Filter out verbose System.Net.Http logs
             .WriteTo.Console(new JsonFormatter(renderMessage: true), restrictedToMinimumLevel: LogEventLevel.Information) // Write to Console to allow log scraping
             .CreateLogger();
+
+        var cliSubcommands = new[] { "register-client", "list-clients", "delete-client" };
+        if (args.Length > 0 && Array.Exists(cliSubcommands, c => c == args[0]))
+        {
+            var exitCode = await W3ChampionsIdentificationService.Oidc.Cli.OidcClientCli.RunAsync(args);
+            Environment.Exit(exitCode);
+            return;
+        }
+
         Log.Information("Starting Identification Service");
         CreateHostBuilder(args).Build().Run();
     }

--- a/W3ChampionsIdentificationService/Program.cs
+++ b/W3ChampionsIdentificationService/Program.cs
@@ -10,7 +10,7 @@ namespace W3ChampionsIdentificationService;
 
 public class Program
 {
-    public static async Task Main(string[] args)
+    public static async Task<int> Main(string[] args)
     {
         Log.Logger = new LoggerConfiguration()
             .MinimumLevel.Debug()
@@ -25,12 +25,13 @@ public class Program
         if (args.Length > 0 && Array.Exists(cliSubcommands, c => c == args[0]))
         {
             var exitCode = await W3ChampionsIdentificationService.Oidc.Cli.OidcClientCli.RunAsync(args);
-            Environment.Exit(exitCode);
-            return;
+            Log.CloseAndFlush();
+            return exitCode;
         }
 
         Log.Information("Starting Identification Service");
         CreateHostBuilder(args).Build().Run();
+        return 0;
     }
 
     public static IHostBuilder CreateHostBuilder(string[] args) =>

--- a/W3ChampionsIdentificationService/Startup.cs
+++ b/W3ChampionsIdentificationService/Startup.cs
@@ -201,14 +201,19 @@ public class Startup
             KnownProxies = { IPAddress.Parse("212.60.5.180") } // Russia gateway
         });
         app.UseRouting();
-        app.UseAuthentication();
-        app.UseAuthorization();
+        // CORS must run BEFORE authentication: for endpoints OpenIddict completes inside
+        // UseAuthentication() (notably /connect/token, handled in-middleware since token
+        // passthrough is disabled), the response is produced before any later middleware — so
+        // CORS has to be in front of UseAuthentication to attach Access-Control-Allow-Origin,
+        // otherwise browser-based OIDC clients are blocked. Policy itself is unchanged; only moved.
         app.UseCors(builder =>
             builder
                 .AllowAnyHeader()
                 .AllowAnyMethod()
                 .SetIsOriginAllowed(_ => true)
                 .AllowCredentials());
+        app.UseAuthentication();
+        app.UseAuthorization();
 
         app.UseEndpoints(endpoints =>
         {

--- a/W3ChampionsIdentificationService/Startup.cs
+++ b/W3ChampionsIdentificationService/Startup.cs
@@ -1,8 +1,14 @@
+using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.IdentityModel.Tokens;
 using MongoDB.Driver;
+using OpenIddict.Abstractions;
+using System;
 using System.Net;
+using System.Security.Cryptography;
 using IPNetwork = Microsoft.AspNetCore.HttpOverrides.IPNetwork;
 using W3ChampionsIdentificationService.Blizzard;
 using W3ChampionsIdentificationService.Config;
@@ -58,6 +64,76 @@ public class Startup
         services.AddTransient<HasPermissionsPermissionFilter>();
 
         services.AddHostedService<MigratorHostedService>();
+
+        services.AddAuthentication(options =>
+        {
+            options.DefaultScheme = CookieAuthenticationDefaults.AuthenticationScheme;
+        })
+        .AddCookie(CookieAuthenticationDefaults.AuthenticationScheme, options =>
+        {
+            options.Cookie.Name = "w3c-idp-session";
+            options.Cookie.HttpOnly = true;
+            options.Cookie.SecurePolicy = CookieSecurePolicy.Always;
+            options.Cookie.SameSite = SameSiteMode.Lax;
+            options.ExpireTimeSpan = TimeSpan.FromMinutes(30);
+            options.SlidingExpiration = false;
+        });
+
+        // Project convention: OidcSigningKeyPem is "" in local dev (env var unset) and set in prod.
+        // When set, load it for signing; when empty, fall back to OpenIddict's ephemeral
+        // development certificate so `dotnet run` boots (no startup crash — matches how the
+        // service tolerates missing config today).
+        var appConfig = services.BuildServiceProvider().GetRequiredService<IAppConfig>();
+        var hasOidcKey = !string.IsNullOrEmpty(appConfig.OidcSigningKeyPem);
+        var oidcRsa = RSA.Create();
+        if (hasOidcKey)
+            oidcRsa.ImportFromPem(appConfig.OidcSigningKeyPem);
+
+        services.AddOpenIddict()
+            .AddCore(core =>
+            {
+                core.UseMongoDb(options =>
+                {
+                    options.UseDatabase(
+                        new MongoClient(appConfig.MongoConnectionString)
+                            .GetDatabase(appConfig.DatabaseName));
+                });
+            })
+            .AddServer(server =>
+            {
+                server
+                    .SetAuthorizationEndpointUris("/connect/authorize")
+                    .SetTokenEndpointUris("/connect/token")
+                    .SetUserInfoEndpointUris("/connect/userinfo")
+                    .SetIssuer(new Uri(appConfig.OidcIssuer));
+
+                server
+                    .AllowAuthorizationCodeFlow()
+                    .RequireProofKeyForCodeExchange();
+
+                if (hasOidcKey)
+                    server.AddSigningKey(new RsaSecurityKey(oidcRsa));
+                else
+                    server.AddDevelopmentSigningCertificate();
+
+                // OpenIddict also requires an ENCRYPTION credential (authorization codes are
+                // encrypted by default). A development cert works for local dev.
+                // TODO(prod): supply a stable encryption key for production.
+                server.AddDevelopmentEncryptionCertificate();
+
+                server.UseAspNetCore(aspnet =>
+                {
+                    aspnet.EnableAuthorizationEndpointPassthrough();
+                    aspnet.EnableTokenEndpointPassthrough();
+                    aspnet.EnableUserInfoEndpointPassthrough();
+                });
+            })
+            .AddValidation(validation =>
+            {
+                validation.UseLocalServer();
+                validation.UseAspNetCore();
+            });
+
         Log.Information("Services configured");
     }
 
@@ -71,6 +147,8 @@ public class Startup
             KnownProxies = { IPAddress.Parse("212.60.5.180") } // Russia gateway
         });
         app.UseRouting();
+        app.UseAuthentication();
+        app.UseAuthorization();
         app.UseCors(builder =>
             builder
                 .AllowAnyHeader()

--- a/W3ChampionsIdentificationService/Startup.cs
+++ b/W3ChampionsIdentificationService/Startup.cs
@@ -123,6 +123,11 @@ public class Startup
                     .AllowAuthorizationCodeFlow()
                     .RequireProofKeyForCodeExchange();
 
+                // Register the optional scopes the IdP supports so OpenIddict recognizes them
+                // (unregistered scopes are rejected) and discovery advertises them. `openid`
+                // is implicit and must not be registered here.
+                server.RegisterScopes(OpenIddictConstants.Scopes.Email, OpenIddictConstants.Scopes.Profile);
+
                 // Signing credential: prod uses the configured RSA key; local dev (no key) uses an
                 // ephemeral development certificate so the service boots without the secret.
                 if (hasOidcKey)

--- a/W3ChampionsIdentificationService/Startup.cs
+++ b/W3ChampionsIdentificationService/Startup.cs
@@ -173,7 +173,12 @@ public class Startup
                 server.UseAspNetCore(aspnet =>
                 {
                     aspnet.EnableAuthorizationEndpointPassthrough();
-                    aspnet.EnableTokenEndpointPassthrough();
+                    // Token endpoint is NOT in passthrough — OpenIddict handles /connect/token
+                    // internally. Passthrough is only needed when a custom controller produces
+                    // the token response; we have no such controller, so letting OpenIddict's
+                    // built-in handler process the authorization-code exchange is both correct
+                    // and sufficient (it validates the code, re-emits the claims+destinations
+                    // stored by OidcAuthorizeController.SignIn, and mints access/id tokens).
                     aspnet.EnableUserInfoEndpointPassthrough();
                 });
             })

--- a/W3ChampionsIdentificationService/Startup.cs
+++ b/W3ChampionsIdentificationService/Startup.cs
@@ -1,9 +1,12 @@
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.AspNetCore.DataProtection.KeyManagement;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.IdentityModel.Tokens;
+using MongoDB.Bson;
 using MongoDB.Driver;
 using OpenIddict.Abstractions;
 using System;
@@ -23,6 +26,7 @@ using W3ChampionsIdentificationService.RolesAndPermissions.Contracts;
 using W3ChampionsIdentificationService.RolesAndPermissions.Repositories;
 using W3ChampionsIdentificationService.Twitch;
 using W3ChampionsIdentificationService.W3CAuthentication;
+using W3ChampionsIdentificationService.DataProtection;
 using W3ChampionsIdentificationService.Oidc;
 using W3ChampionsIdentificationService.W3CAuthentication.Contracts;
 using W3ChampionsIdentificationService.WebApi.ActionFilters;
@@ -65,6 +69,23 @@ public class Startup
         services.AddTransient<HasPermissionsPermissionFilter>();
 
         services.AddHostedService<MigratorHostedService>();
+
+        // Persist + share the DataProtection key ring in MongoDB. The IdP session cookie below
+        // is encrypted with DataProtection, whose default key ring is EPHEMERAL and per-instance:
+        // a cookie set by one replica (or before a restart) cannot be decrypted by another, which
+        // would loop the user back through login mid-handoff. Backing the key ring with the
+        // already-present MongoDB makes it durable + shared with no new infrastructure.
+        // SetApplicationName MUST be a stable constant so every replica/restart derives the same
+        // protection purpose. (Distinct from OIDC_ENCRYPTION_KEY_PEM, which protects OIDC codes.)
+        var dataProtectionConfig = new AppConfig();
+        var dataProtectionKeysCollection =
+            new MongoClient(dataProtectionConfig.MongoConnectionString)
+                .GetDatabase(dataProtectionConfig.DatabaseName)
+                .GetCollection<BsonDocument>("DataProtectionKeys");
+        services.AddDataProtection()
+            .SetApplicationName("w3c-identification-service");
+        services.Configure<KeyManagementOptions>(options =>
+            options.XmlRepository = new MongoXmlRepository(dataProtectionKeysCollection));
 
         services.AddAuthentication(options =>
         {

--- a/W3ChampionsIdentificationService/Startup.cs
+++ b/W3ChampionsIdentificationService/Startup.cs
@@ -176,19 +176,24 @@ public class Startup
                 }
 
                 // Encryption credential (OpenIddict encrypts authorization codes by default).
-                // Prod MUST supply a stable key, else codes are encrypted with a per-process
-                // ephemeral cert that breaks across restarts/replicas.
                 if (hasOidcEncKey)
                 {
                     var encryptionRsa = RSA.Create();
                     encryptionRsa.ImportFromPem(appConfig.OidcEncryptionKeyPem);
                     server.AddEncryptionKey(new RsaSecurityKey(encryptionRsa));
                 }
+                else if (hasOidcKey)
+                {
+                    // Production (signing key set) MUST have a stable encryption key, else auth codes are
+                    // encrypted with an ephemeral dev cert that breaks across restarts/replicas. Fail fast.
+                    throw new InvalidOperationException(
+                        "OIDC_ENCRYPTION_KEY_PEM must be set when OIDC_SIGNING_KEY_PEM is set (production). " +
+                        "Generate one with: openssl genrsa 2048");
+                }
                 else
                 {
+                    // Local dev (no signing key): ephemeral dev encryption cert is fine.
                     server.AddDevelopmentEncryptionCertificate();
-                    if (hasOidcKey)
-                        Log.Warning("OIDC: production signing key is set but OIDC_ENCRYPTION_KEY_PEM is empty — using an EPHEMERAL dev encryption certificate. Authorization codes will not survive restarts and cannot be decrypted across replicas. Set OIDC_ENCRYPTION_KEY_PEM in production.");
                 }
 
                 server.UseAspNetCore(aspnet =>

--- a/W3ChampionsIdentificationService/Startup.cs
+++ b/W3ChampionsIdentificationService/Startup.cs
@@ -71,7 +71,12 @@ public class Startup
         })
         .AddCookie(CookieAuthenticationDefaults.AuthenticationScheme, options =>
         {
-            options.Cookie.Name = "w3c-idp-session";
+            // __Host- prefix: browsers enforce that such cookies are Secure, have Path="/",
+            // and carry no Domain — i.e. strictly host-only. The settings below satisfy that
+            // (Secure=Always, default Path="/", no Cookie.Domain), hardening against cookie
+            // fixation/subdomain injection. The cookie is read/written via the auth scheme,
+            // so the raw name change is transparent to the rest of the code.
+            options.Cookie.Name = "__Host-w3c-idp-session";
             options.Cookie.HttpOnly = true;
             options.Cookie.SecurePolicy = CookieSecurePolicy.Always;
             options.Cookie.SameSite = SameSiteMode.Lax;
@@ -79,15 +84,19 @@ public class Startup
             options.SlidingExpiration = false;
         });
 
-        // Project convention: OidcSigningKeyPem is "" in local dev (env var unset) and set in prod.
-        // When set, load it for signing; when empty, fall back to OpenIddict's ephemeral
-        // development certificate so `dotnet run` boots (no startup crash — matches how the
-        // service tolerates missing config today).
-        var appConfig = services.BuildServiceProvider().GetRequiredService<IAppConfig>();
+        // Project convention: OIDC key PEMs are "" in local dev (env vars unset) and set in prod.
+        // When set, they are loaded as the signing/encryption credentials; when empty, OpenIddict's
+        // ephemeral development certificates are used so `dotnet run` boots (no startup crash —
+        // matches how the service tolerates missing config today).
+        // AppConfig is a stateless env-var reader with a parameterless ctor, so instantiate it
+        // directly rather than building a throwaway service provider (avoids ASP0000 + a duplicate
+        // DI container).
+        var appConfig = new AppConfig();
         var hasOidcKey = !string.IsNullOrEmpty(appConfig.OidcSigningKeyPem);
-        var oidcRsa = RSA.Create();
-        if (hasOidcKey)
-            oidcRsa.ImportFromPem(appConfig.OidcSigningKeyPem);
+        var hasOidcEncKey = !string.IsNullOrEmpty(appConfig.OidcEncryptionKeyPem);
+
+        if (!Uri.TryCreate(appConfig.OidcIssuer, UriKind.Absolute, out var issuerUri))
+            throw new InvalidOperationException($"OIDC_ISSUER is not a valid absolute URI: '{appConfig.OidcIssuer}'");
 
         services.AddOpenIddict()
             .AddCore(core =>
@@ -101,25 +110,47 @@ public class Startup
             })
             .AddServer(server =>
             {
+                // These /connect/* endpoints are the NEW standards-compliant OIDC surface.
+                // They are distinct from the legacy bespoke /api/oauth/* endpoints in
+                // AuthorizationController (e.g. OIDC "/connect/userinfo" vs legacy "/api/oauth/user-info").
                 server
                     .SetAuthorizationEndpointUris("/connect/authorize")
                     .SetTokenEndpointUris("/connect/token")
                     .SetUserInfoEndpointUris("/connect/userinfo")
-                    .SetIssuer(new Uri(appConfig.OidcIssuer));
+                    .SetIssuer(issuerUri);
 
                 server
                     .AllowAuthorizationCodeFlow()
                     .RequireProofKeyForCodeExchange();
 
+                // Signing credential: prod uses the configured RSA key; local dev (no key) uses an
+                // ephemeral development certificate so the service boots without the secret.
                 if (hasOidcKey)
-                    server.AddSigningKey(new RsaSecurityKey(oidcRsa));
+                {
+                    var signingRsa = RSA.Create();
+                    signingRsa.ImportFromPem(appConfig.OidcSigningKeyPem);
+                    server.AddSigningKey(new RsaSecurityKey(signingRsa));
+                }
                 else
+                {
                     server.AddDevelopmentSigningCertificate();
+                }
 
-                // OpenIddict also requires an ENCRYPTION credential (authorization codes are
-                // encrypted by default). A development cert works for local dev.
-                // TODO(prod): supply a stable encryption key for production.
-                server.AddDevelopmentEncryptionCertificate();
+                // Encryption credential (OpenIddict encrypts authorization codes by default).
+                // Prod MUST supply a stable key, else codes are encrypted with a per-process
+                // ephemeral cert that breaks across restarts/replicas.
+                if (hasOidcEncKey)
+                {
+                    var encryptionRsa = RSA.Create();
+                    encryptionRsa.ImportFromPem(appConfig.OidcEncryptionKeyPem);
+                    server.AddEncryptionKey(new RsaSecurityKey(encryptionRsa));
+                }
+                else
+                {
+                    server.AddDevelopmentEncryptionCertificate();
+                    if (hasOidcKey)
+                        Log.Warning("OIDC: production signing key is set but OIDC_ENCRYPTION_KEY_PEM is empty — using an EPHEMERAL dev encryption certificate. Authorization codes will not survive restarts and cannot be decrypted across replicas. Set OIDC_ENCRYPTION_KEY_PEM in production.");
+                }
 
                 server.UseAspNetCore(aspnet =>
                 {

--- a/W3ChampionsIdentificationService/Startup.cs
+++ b/W3ChampionsIdentificationService/Startup.cs
@@ -23,6 +23,7 @@ using W3ChampionsIdentificationService.RolesAndPermissions.Contracts;
 using W3ChampionsIdentificationService.RolesAndPermissions.Repositories;
 using W3ChampionsIdentificationService.Twitch;
 using W3ChampionsIdentificationService.W3CAuthentication;
+using W3ChampionsIdentificationService.Oidc;
 using W3ChampionsIdentificationService.W3CAuthentication.Contracts;
 using W3ChampionsIdentificationService.WebApi.ActionFilters;
 using Serilog;
@@ -97,6 +98,18 @@ public class Startup
 
         if (!Uri.TryCreate(appConfig.OidcIssuer, UriKind.Absolute, out var issuerUri))
             throw new InvalidOperationException($"OIDC_ISSUER is not a valid absolute URI: '{appConfig.OidcIssuer}'");
+
+        // Warn when running with a production signing key but the issuer is not among the
+        // handoff return-URL allowlist origins. In that case the SSO handoff will 400
+        // (HandoffReturnUrlValidator rejects the authorize return URL) mid-flow.
+        // Local dev intentionally uses a localhost issuer and never exercises the handoff,
+        // so this is a prod-only warning (gated on hasOidcKey = the prod signal).
+        if (hasOidcKey && !HandoffReturnUrlValidator.IsAllowed(appConfig.OidcIssuer))
+            Log.Warning(
+                "OIDC_ISSUER '{Issuer}' is not in the handoff return-URL allowlist [{Allowed}]; " +
+                "the SSO handoff will reject the authorize return URL with HTTP 400. " +
+                "Set OIDC_ISSUER to one of the allowed origins.",
+                appConfig.OidcIssuer, string.Join(", ", HandoffReturnUrlValidator.AllowedOrigins));
 
         services.AddOpenIddict()
             .AddCore(core =>

--- a/W3ChampionsIdentificationService/W3ChampionsIdentificationService.csproj
+++ b/W3ChampionsIdentificationService/W3ChampionsIdentificationService.csproj
@@ -1,6 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <ItemGroup>
+        <PackageReference Include="OpenIddict.AspNetCore" />
+        <PackageReference Include="OpenIddict.MongoDb" />
         <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" />
         <PackageReference Include="MongoDB.Driver" />
         <PackageReference Include="System.IdentityModel.Tokens.Jwt" />


### PR DESCRIPTION
Turns `identification-service` into a standard **OIDC Identity Provider** (OpenIddict 7.5.0, MongoDB store) that mints OIDC tokens from the existing Battle.net/battletag identity — enabling SSO into the self-hosted Quackback feedback portal (`feedback.w3champions.com`) **with no Battle.net-side changes**. Purely additive: the existing `/api/oauth/*` endpoints and the w3c JWT format are untouched.

## What this adds
- **OIDC endpoints** (OpenIddict built-in + passthrough controllers): `/.well-known/openid-configuration`, JWKS, `GET /connect/authorize`, `POST /connect/token` (handled internally by OpenIddict), `GET/POST /connect/userinfo`.
- **`POST /connect/handoff`** — the website hands the user's existing `W3ChampionsJWT` to the IdP via a one-time browser POST; the IdP validates it (signature + `exp` with `JWT_PUBLIC_KEY`), establishes a 30-min host-scoped `__Host-w3c-idp-session` cookie, and resumes the authorize flow. **The session cookie is never widened.**
- **Dedicated OIDC keys** — `OIDC_SIGNING_KEY_PEM` (token signing) and `OIDC_ENCRYPTION_KEY_PEM` (auth-code encryption), fully separate from the w3c `JWT_PRIVATE_KEY`. Prod requires both (fails fast otherwise); local dev uses ephemeral dev certs.
- **Per-client claim release gated on granted scopes**: `sub`=battleTag, `name`=full battleTag (`profile`), `email`=`<battletag>@w3champions.invalid` (`email`, non-deliverable RFC-6761 TLD; required because Better Auth rejects login with no email). `isAdmin`/`permissions`/`bnetId` are **not** released to Quackback.
- **Client-management CLI** (`register-client` / `list-clients` / `delete-client`) run via `docker compose exec`; secrets are CSPRNG-generated, PBKDF2-hashed by OpenIddict, printed once.
- **DataProtection key ring persisted to MongoDB** so the IdP session cookie survives restarts/replicas.

## Forced dependency bumps (verified safe)
OpenIddict 7.5.0 transitively requires these; both verified by the full test suite (incl. live-Mongo integration) and a JWT byte-compat regression test:
- `MongoDB.Driver` **2.30.0 → 3.6.0** (low exposure: all string IDs, no Guid/LINQ2/GridFS/custom serializers). **Requires MongoDB server ≥ 4.2** — verify before deploy.
- `Microsoft.IdentityModel.*` **6.x → 8.16.0** (else the legacy 6.34 JWT handler throws `TypeLoadException` at runtime under OpenIddict). The minted w3c-JWT payload is byte-compatible (array `permissions`, numeric `exp`, no new claims), so ecosystem consumers that validate by signature are unaffected — locked by `ExistingOauthEndpointsRegressionTests`.

## Security
Dedicated signing/encryption keys (token-type isolation), PKCE S256 required, claim minimization, exact-origin `return`-URL allowlist, **handoff Origin check against the website origin (apex+www) to prevent login CSRF**, `__Host-` cookie (Secure/HttpOnly/SameSite=Lax), `prompt=none`→`login_required` and `prompt=login`→forced reauth, CORS before authentication.

## Known limitation (non-blocking)
`prompt=login` is **partially honored**: the IdP clears its own session cookie and re-runs the website handoff (refreshing the IdP session and re-validating the w3c JWT), but it cannot force a fresh Battle.net **credential** prompt on its own — the website holds the sole Battle.net session. Full forced-reauth / account-switch would require the website's `/sso-continue` to honor a force-login signal (a small cross-repo enhancement, best done alongside the future embeddable widget). **Not used by Quackback** (Better Auth's normal login doesn't send `prompt=login`), so there is no current impact. `prompt=none` → `login_required` is fully correct.

## New env vars (set in test env first, then prod)
- `OIDC_SIGNING_KEY_PEM`, `OIDC_ENCRYPTION_KEY_PEM` — `openssl genrsa 2048` each, `\n`-escaped (two **separate** keys).
- `OIDC_ISSUER` — must equal a handoff-allowlist origin (`https://identification-service.w3champions.com` or the `.test.` host).
- `WEBSITE_LOGIN_URL` — the origin that serves `/sso-continue` (apex+www both accepted).

## Deploy order
**This PR merges/deploys FIRST.** Deploy to `identification-service.test.w3champions.com` → verify discovery/authorize/token + the `/api/oauth/*` regression → deploy to prod → `register-client --client-id quackback --redirect-uri https://feedback.w3champions.com/api/auth/oauth2/callback/custom-oidc --scopes openid,profile,email` (record the printed secret) → then the website PR and the docker-compose PR can proceed. **Pre-deploy gate: MongoDB server ≥ 4.2.**

## Test plan
- [x] `dotnet build -c Release` 0 errors; `dotnet format --verify-no-changes` clean (CI gate)
- [x] Full suite: 82 OIDC unit tests + integration tests pass on the 3.x driver against live Mongo
- [ ] Deploy to test env; `curl /.well-known/openid-configuration`; JWKS kid ≠ w3c-JWT kid
- [ ] `register-client` prints a secret once; `list-clients` shows `quackback`
- [ ] `/connect/authorize` without cookie → 302 to website `/sso-continue`; with disallowed `return` → 400; cross-site Origin handoff → 400
- [ ] Full handoff → code → token → userinfo (sub/name/email, no isAdmin)
- [ ] Existing `GET /api/oauth/user-info` & `/api/oauth/token` behave identically

> Reviewed end-to-end with an automated multi-pass Codex review loop (token flow, login-CSRF, OIDC prompt semantics, scope→userinfo, CI format, key continuity).
