### PR TITLE
fix(oidc): make PKCE optional so confidential clients (Quackback) can sign in

### DIFF
--- a/W3ChampionsIdentificationService.Tests/UnitTests/Oidc/OidcClientCliArgsTests.cs
+++ b/W3ChampionsIdentificationService.Tests/UnitTests/Oidc/OidcClientCliArgsTests.cs
@@ -22,6 +22,7 @@ public class OidcClientCliArgsTests
         Assert.AreEqual("https://feedback.w3champions.com/callback", result.RedirectUri);
         Assert.AreEqual(new[] { "openid", "email" }, result.Scopes);
         Assert.IsFalse(result.Update);
+        Assert.IsTrue(result.RequirePkce); // PKCE required unless --no-pkce is passed
     }
 
     [Test]
@@ -49,6 +50,20 @@ public class OidcClientCliArgsTests
         ]);
 
         Assert.IsTrue(result.Update);
+    }
+
+    [Test]
+    public void ParseRegisterArgs_NoPkceFlag_SetsRequirePkceFalse()
+    {
+        var result = OidcClientCli.ParseRegisterArgs(
+        [
+            "register-client",
+            "--client-id", "quackback",
+            "--redirect-uri", "https://feedback.w3champions.com/callback",
+            "--no-pkce"
+        ]);
+
+        Assert.IsFalse(result.RequirePkce);
     }
 
     [Test]

--- a/W3ChampionsIdentificationService/Oidc/Cli/OidcClientCli.cs
+++ b/W3ChampionsIdentificationService/Oidc/Cli/OidcClientCli.cs
@@ -61,7 +61,7 @@ public static class OidcClientCli
         string.Equals(parsed.Scheme, "https", StringComparison.OrdinalIgnoreCase);
 
     /// <summary>Parsed + validated register-client arguments. Public for testability.</summary>
-    public sealed record RegisterArgs(string ClientId, string RedirectUri, string[] Scopes, bool Update);
+    public sealed record RegisterArgs(string ClientId, string RedirectUri, string[] Scopes, bool Update, bool RequirePkce);
 
     /// <summary>
     /// Parses and validates the register-client argument vector. Throws <see cref="ArgumentException"/>
@@ -74,6 +74,7 @@ public static class OidcClientCli
         string clientId = null, redirectUri = null;
         string[] scopes = ["openid", "profile", "email"];
         bool update = false;
+        bool requirePkce = true;
 
         for (int i = 1; i < args.Length; i++)
         {
@@ -83,6 +84,7 @@ public static class OidcClientCli
                 case "--redirect-uri": redirectUri = NextValue(args, ref i); break;
                 case "--scopes": scopes = NextValue(args, ref i).Split(','); break;
                 case "--update": update = true; break;
+                case "--no-pkce": requirePkce = false; break;
             }
         }
 
@@ -91,7 +93,7 @@ public static class OidcClientCli
         if (!IsValidHttpsRedirectUri(redirectUri))
             throw new ArgumentException($"redirect-uri must be an absolute HTTPS URL, got: {redirectUri}");
 
-        return new RegisterArgs(clientId, redirectUri, scopes, update);
+        return new RegisterArgs(clientId, redirectUri, scopes, update, requirePkce);
     }
 
     /// <summary>
@@ -139,8 +141,13 @@ public static class OidcClientCli
                 Permissions.Scopes.Email,
             },
             RedirectUris = { new Uri(parsed.RedirectUri) },
-            Requirements = { Requirements.Features.ProofKeyForCodeExchange },
         };
+
+        // PKCE is required by default (defense-in-depth, esp. for public clients). Confidential
+        // clients that cannot send PKCE — e.g. Quackback's portal Custom OIDC, which is protected
+        // by its client secret — are registered with --no-pkce to omit the requirement.
+        if (parsed.RequirePkce)
+            descriptor.Requirements.Add(Requirements.Features.ProofKeyForCodeExchange);
 
         if (!parsed.Scopes.Contains("profile", StringComparer.OrdinalIgnoreCase))
             descriptor.Permissions.Remove(Permissions.Scopes.Profile);
@@ -201,7 +208,7 @@ public static class OidcClientCli
 
     private static int Usage()
     {
-        Console.Error.WriteLine("Usage: register-client --client-id <id> --redirect-uri <uri> [--scopes openid,profile,email] [--update rotates the secret]");
+        Console.Error.WriteLine("Usage: register-client --client-id <id> --redirect-uri <uri> [--scopes openid,profile,email] [--no-pkce omits the PKCE requirement for confidential clients that can't send it] [--update rotates the secret]");
         Console.Error.WriteLine("       list-clients");
         Console.Error.WriteLine("       delete-client --client-id <id>");
         return 1;

--- a/W3ChampionsIdentificationService/Startup.cs
+++ b/W3ChampionsIdentificationService/Startup.cs
@@ -153,9 +153,14 @@ public class Startup
                     .SetUserInfoEndpointUris("/connect/userinfo")
                     .SetIssuer(issuerUri);
 
+                // PKCE is NOT globally required. Confidential clients that authenticate with a
+                // client secret (e.g. Quackback's portal Custom OIDC, which deliberately does not
+                // send a code_challenge) cannot complete the flow if PKCE is mandatory. PKCE stays
+                // supported/advertised (S256) and is enforced per-client via the client's
+                // Requirements — register-client adds it by default; pass --no-pkce to omit it for
+                // confidential clients that can't send it.
                 server
-                    .AllowAuthorizationCodeFlow()
-                    .RequireProofKeyForCodeExchange();
+                    .AllowAuthorizationCodeFlow();
 
                 // Register the optional scopes the IdP supports so OpenIddict recognizes them
                 // (unregistered scopes are rejected) and discovery advertises them. `openid`


### PR DESCRIPTION
## Problem

Quackback login fails at the IdP authorize step:

```
error: invalid_request
error_description: The mandatory 'code_challenge' parameter is missing.   (OpenIddict ID2029)
```

**Root cause — a design incompatibility, not a misconfiguration:** Quackback's portal **Custom OIDC deliberately does not send PKCE**. Confirmed in their source:
- `apps/web/src/lib/server/auth/sso-test.ts`: *"NO PKCE — production genericOAuth"*, *"Mirror production: no PKCE on the authorize request"*
- `oidc-error-explain.ts`: *"PKCE code_verifier mismatch (your IdP may not support PKCE for confidential clients — check IdP settings)"*

There is **no Quackback setting to enable PKCE** for its Custom OIDC client. Our IdP, meanwhile, required PKCE both globally (`Startup` `.RequireProofKeyForCodeExchange()`) and per-client (`register-client`). Since Quackback can't change, the IdP has to stop mandating PKCE for this client.

## Change

- **`Startup.cs`** — drop the global `.RequireProofKeyForCodeExchange()`. PKCE remains **supported and advertised** (`code_challenge_methods_supported: ["S256"]`); it's just no longer mandatory server-wide.
- **`OidcClientCli.cs`** — the per-client PKCE requirement is now **opt-out**: ON by default (secure default, esp. for future public clients), with a new `--no-pkce` flag to omit it for confidential clients that can't send PKCE.
- **Tests** — assert the default requires PKCE and that `--no-pkce` clears it.

## Why this is safe for this client

`quackback` is a **confidential client** (`ClientType=Confidential`, registered with a client secret) and exchanges the code at the token endpoint using that secret. The secret already provides PKCE's core protection — an intercepted authorization code is useless without it. Combined with **exact `redirect_uri` matching**, **`state`**, **one-time short-lived codes**, and **TLS end-to-end**, dropping PKCE for this confidential client is a standard, low-risk configuration. PKCE primarily protects *public* clients (SPA/mobile) that can't hold a secret — those remain protected (register them without `--no-pkce`).

This is a deliberate, scoped deviation from the spec's §8 "PKCE-S256" for confidential clients that cannot support PKCE.

## Blast radius

Limited to the OIDC `/connect/*` endpoints (only `quackback` uses them today). The legacy Battle.net `/api/oauth/*` flow is OpenIddict-independent and **untouched**.

## Verification
- [x] `dotnet build -c Release` → 0 errors
- [x] `dotnet test --filter OidcClientCliArgsTests` → 8/8 pass (incl. new `--no-pkce` coverage)
- [x] `dotnet format --verify-no-changes` → clean (CI gate)

## Deploy / follow-up (operator)
After this is merged and deployed to prod, **re-register the quackback client without PKCE**:

```bash
docker exec identification-service dotnet W3ChampionsIdentificationService.dll \
  register-client --client-id quackback \
  --redirect-uri https://feedback.w3champions.com/api/auth/oauth2/callback/custom-oidc \
  --scopes openid,profile,email --no-pkce --update
```

(`--update` rotates the secret — re-paste it into Quackback's Custom OIDC config.) The existing `/connect/*` endpoints and discovery are otherwise unchanged.
