### PR TITLE
feat(oidc): add /connect/idp-logout for single logout

### DIFF
--- a/W3ChampionsIdentificationService/Oidc/OidcLogoutController.cs
+++ b/W3ChampionsIdentificationService/Oidc/OidcLogoutController.cs
@@ -1,0 +1,31 @@
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Mvc;
+
+namespace W3ChampionsIdentificationService.Oidc;
+
+/// <summary>
+/// GET /connect/idp-logout — front-channel single logout.
+/// Clears the __Host-w3c-idp-session SSO cookie so that logging out of the website also
+/// ends the IdP's OIDC SSO session. The website loads this URL as a hidden image during
+/// logout; a subsequent OIDC login (e.g. Quackback) then finds no IdP session, bounces
+/// back to the website, and — with no W3ChampionsJWT — re-prompts for Battle.net instead
+/// of silently reusing the (up-to-30-min) IdP session.
+///
+/// No CSRF/Origin gate: ending a session is not a sensitive state change worth protecting
+/// (a forced logout is, at worst, a re-login prompt), and a cross-origin &lt;img&gt; GET
+/// carries no Origin header to check anyway. SignOutAsync emits the clearing Set-Cookie
+/// whether or not a session is present, so the call is safe and idempotent.
+/// </summary>
+[ApiController]
+public class OidcLogoutController : ControllerBase
+{
+    [HttpGet("~/connect/idp-logout")]
+    public async Task<IActionResult> Logout()
+    {
+        await HttpContext.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
+        Response.Headers.CacheControl = "no-store";
+        return NoContent();
+    }
+}


### PR DESCRIPTION
## Problem
Logging out of `w3champions.com` only clears the `W3ChampionsJWT` cookie. The id-service keeps its **own** OIDC SSO session — the `__Host-w3c-idp-session` cookie (HttpOnly, **30-min, non-sliding**, set by `/connect/handoff`). Website logout never touches it, so within that window a fresh OIDC login (e.g. Quackback "Sign in with w3champions") finds the still-valid IdP session in `/connect/authorize` and issues a token **silently, without re-checking the website** — i.e. "logging out doesn't log out."

## Change
Add `GET /connect/idp-logout`:
- `SignOutAsync(cookie)` → clears `__Host-w3c-idp-session`; returns `204` + `Cache-Control: no-store`.
- The website (separate PR) loads it as a hidden `<img>` during logout. The browser honours the clearing `Set-Cookie` from the same-site response even though it can't read the 204 body, and an image load needs no CORS.

After both sides ship: website logout ends the IdP session → the next OIDC login bounces to `/sso-continue` → no `W3ChampionsJWT` → Battle.net re-prompt. ✅

## Security
No CSRF/Origin gate, deliberately: ending a session is not a sensitive state change (a forced logout is at worst a re-login prompt), and a cross-origin `<img>` GET carries no `Origin` to check. `SignOutAsync` emits the clearing `Set-Cookie` whether or not a session exists, so the endpoint is idempotent. The custom path (`/connect/idp-logout`, mirroring `/connect/handoff`) avoids any collision with OpenIddict's end-session endpoint (not configured).

## Scope / limits
Ends the **IdP SSO session** (so new logins re-prompt). It does **not** terminate an already-open **Quackback** session — that's Quackback's own cookie and would need OIDC back-channel logout (out of scope; revocation/SLO-to-RP was descoped in the original spec).

## Verification
- [x] `dotnet build -c Release` → 0 errors
- [x] `dotnet format --verify-no-changes` → clean (CI gate)
- [ ] Post-deploy: `curl -i https://identification-service.w3champions.com/connect/idp-logout` → `204` + `Set-Cookie: __Host-w3c-idp-session=; expires=…1970…`

## Deploy order
Deploy **this PR first**, then the website PR (so the endpoint exists when the website starts calling it; a missing endpoint just no-ops the cleanup — no breakage).
