### PR TITLE
Add Warnings admin permission

### DIFF
--- a/W3ChampionsIdentificationService/RolesAndPermissions/Permission.cs
+++ b/W3ChampionsIdentificationService/RolesAndPermissions/Permission.cs
@@ -15,16 +15,16 @@ public class Permission : IIdentifiable
 
 public enum EPermission
 {
-    Permissions,
-    Moderation,
-    Queue,
-    Logs,
-    Maps,
-    Tournaments,
-    Content,
-    Proxies,
-    Warnings,
-    SmurfCheckerQuery,
-    SmurfCheckerQueryExplanation,
-    SmurfCheckerAdministration,
+    Permissions = 0,
+    Moderation = 1,
+    Queue = 2,
+    Logs = 3,
+    Maps = 4,
+    Tournaments = 5,
+    Content = 6,
+    Proxies = 7,
+    SmurfCheckerQuery = 8,
+    SmurfCheckerQueryExplanation = 9,
+    SmurfCheckerAdministration = 10,
+    Warnings = 11,
 }

--- a/W3ChampionsIdentificationService/RolesAndPermissions/Permission.cs
+++ b/W3ChampionsIdentificationService/RolesAndPermissions/Permission.cs
@@ -23,6 +23,7 @@ public enum EPermission
     Tournaments,
     Content,
     Proxies,
+    Warnings,
     SmurfCheckerQuery,
     SmurfCheckerQueryExplanation,
     SmurfCheckerAdministration,


### PR DESCRIPTION
Adds a separate Warnings permission so warning tools can be granted without full moderation access.

Try it by giving an admin the Warnings permission, signing in again, and opening the warnings admin pages.
