### PR TITLE
Add Jobs admin permission

### DIFF
--- a/W3ChampionsIdentificationService/RolesAndPermissions/Permission.cs
+++ b/W3ChampionsIdentificationService/RolesAndPermissions/Permission.cs
@@ -27,4 +27,5 @@ public enum EPermission
     SmurfCheckerQueryExplanation = 9,
     SmurfCheckerAdministration = 10,
     Warnings = 11,
+    Jobs = 12,
 }


### PR DESCRIPTION
Adds the `Jobs` permission (`12`), backing the admin job runner (w3champions/website-backend#541). Registering it here first lets it be granted ahead of the runner landing. Siblings: w3champions/website-backend#546, w3champions/website#1113, w3champions/chat-service#35.

🤖 Generated with [Claude Code](https://claude.com/claude-code)